### PR TITLE
pyupgrade @ 3.7

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,8 +89,8 @@ htmlhelp_basename = "%sdoc" % about["__title__"]
 latex_documents = [
     (
         "index",
-        "{0}.tex".format(about["__package_name__"]),
-        "{0} Documentation".format(about["__title__"]),
+        "{}.tex".format(about["__package_name__"]),
+        "{} Documentation".format(about["__title__"]),
         about["__author__"],
         "manual",
     )
@@ -100,7 +100,7 @@ man_pages = [
     (
         "index",
         about["__package_name__"],
-        "{0} Documentation".format(about["__title__"]),
+        "{} Documentation".format(about["__title__"]),
         about["__author__"],
         1,
     )
@@ -109,8 +109,8 @@ man_pages = [
 texinfo_documents = [
     (
         "index",
-        "{0}".format(about["__package_name__"]),
-        "{0} Documentation".format(about["__title__"]),
+        "{}".format(about["__package_name__"]),
+        "{} Documentation".format(about["__title__"]),
         about["__author__"],
         about["__package_name__"],
         about["__description__"],

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,5 +1,3 @@
-# -*- coding: utf8 - *-
-
 from unihan_db import bootstrap
 from unihan_db.tables import Base, Unhn
 

--- a/unihan_db/__init__.py
+++ b/unihan_db/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf8 - *-
-
 import os
 
 from appdirs import AppDirs

--- a/unihan_db/_compat.py
+++ b/unihan_db/_compat.py
@@ -1,4 +1,3 @@
-# -*- coding: utf8 -*-
 # flake8: NOQA
 import sys
 

--- a/unihan_db/bootstrap.py
+++ b/unihan_db/bootstrap.py
@@ -125,7 +125,7 @@ def is_bootstrapped(metadata):
     if TABLE_NAME in metadata.tables.keys():
         table = metadata.tables[TABLE_NAME]
 
-        if set(fields) == set(c.name for c in table.columns):
+        if set(fields) == {c.name for c in table.columns}:
             return True
         else:
             return False


### PR DESCRIPTION
```
pip install pyupgrade autoflake; \
pyupgrade --py37 tests/**/*.py docs/**/*.py unihan_db/**/*.py; \
poetry run autoflake tests/**/*.py docs/**/*.py unihan_db/**/*.py -i --ignore-init-module-imports --exclude unihan_db/_compat.py; \
make black isort
```

https://github.com/cihai/unihan-etl/pull/252