### PR TITLE
docs: Move to `gp-libs` (our internal helpers for sphinx)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,17 @@ $ pip install --user --upgrade --pre unihan-db
 - Add [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear) (#300)
 - Add [flake8-comprehensions](https://github.com/adamchainz/flake8-comprehensions) (#301)
 
+### Documentation
+
+- Render changelog in [`linkify_issues`] (#303)
+- Fix Table of contents rendering with sphinx autodoc with [`sphinx_toctree_autodoc_fix`] (#303)
+- Test doctests in our docs via [`pytest_doctest_docutils`] (built on [`doctest_docutils`]) (#303)
+
+[`linkify_issues`]: https://gp-libs.git-pull.com/linkify_issues/
+[`sphinx_toctree_autodoc_fix`]: https://gp-libs.git-pull.com/sphinx_toctree_autodoc_fix/
+[`pytest_doctest_docutils`]: https://gp-libs.git-pull.com/doctest/pytest.html
+[`doctest_docutils`]: https://gp-libs.git-pull.com/doctest
+
 ## unihan-db 0.6.0 (2022-08-21)
 
 ### Internal

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,12 +30,18 @@ extensions = [
     "sphinx.ext.linkcode",
     "sphinx_inline_tabs",
     "sphinx_copybutton",
-    "sphinx_autoissues",
     "sphinxext.opengraph",
     "sphinxext.rediraffe",
     "myst_parser",
+    "sphinx_toctree_autodoc_fix",
+    "linkify_issues",
 ]
-myst_enable_extensions = ["colon_fence", "substitution", "replacements"]
+myst_enable_extensions = [
+    "colon_fence",
+    "substitution",
+    "replacements",
+    "strikethrough",
+]
 
 templates_path = ["_templates"]
 
@@ -87,9 +93,8 @@ html_sidebars = {
     ]
 }
 
-# sphinx-autoissues
-issuetracker = "github"
-issuetracker_project = "cihai/unihan-db"
+# linkify_issues
+issue_url_tpl = "https://github.com/cihai/unihan-db/issues/{issue_id}"
 
 # sphinxext.opengraph
 ogp_site_url = about["__docs__"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -681,14 +681,6 @@ testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "diff-cover (>=6.5.1)", 
 type_comments = ["typed-ast (>=1.5.4)"]
 
 [[package]]
-name = "sphinx-autoissues"
-version = "0.0.1"
-description = "Sphinx integration with different issuetrackers"
-category = "dev"
-optional = false
-python-versions = ">=3.7,<4.0"
-
-[[package]]
 name = "sphinx-basic-ng"
 version = "0.0.1a12"
 description = "A modern skeleton for Sphinx themes."
@@ -985,7 +977,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "a08936d1403b83144a5dc0e79bda762fb7d07ddf2a0420974c006ba7eae6e2db"
+content-hash = "776204350d9f424ff5c01f9ba247e0ace68fb217eb02169b10a07fd62f0d70a3"
 
 [metadata.files]
 alabaster = [
@@ -1418,10 +1410,6 @@ sphinx-autobuild = [
 sphinx-autodoc-typehints = [
     {file = "sphinx_autodoc_typehints-1.19.2-py3-none-any.whl", hash = "sha256:3d761de928d5a86901331133d6d4a2552afa2e798ebcfc0886791792aeb4dd9a"},
     {file = "sphinx_autodoc_typehints-1.19.2.tar.gz", hash = "sha256:872fb2d7b3d794826c28e36edf6739e93549491447dcabeb07c58855e9f914de"},
-]
-sphinx-autoissues = [
-    {file = "sphinx-autoissues-0.0.1.tar.gz", hash = "sha256:a308fd914d700ff2aa2b4584c29975a030ede7171898130ec816eca7ec2c8ce8"},
-    {file = "sphinx_autoissues-0.0.1-py3-none-any.whl", hash = "sha256:07503b774c3a64b97d2614fa409410316fbfeb87ba4553dbe3a7d2131b7453a0"},
 ]
 sphinx-basic-ng = [
     {file = "sphinx_basic_ng-0.0.1a12-py3-none-any.whl", hash = "sha256:e8b6efd2c5ece014156de76065eda01ddfca0fee465aa020b1e3c12f84570bbe"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,6 @@ sphinx-inline-tabs = { version = "*", python = "^3.7" }
 sphinxext-opengraph = "*"
 sphinx-copybutton = "*"
 sphinxext-rediraffe = "*"
-sphinx-autoissues = "*"
 myst_parser = "*"
 docutils = "~0.18.0"
 
@@ -99,7 +98,6 @@ docs = [
   "sphinxext-opengraph",
   "sphinx-inline-tabs",
   "sphinxext-rediraffe",
-  "sphinx-autoissues",
   "myst_parser",
   "furo",
 ]


### PR DESCRIPTION
## Changes

- Render changelog in [`linkify_issues`] 
- Fix Table of contents rendering with sphinx autodoc with [`sphinx_toctree_autodoc_fix`]
- Deprecate `sphinx-autoapi`, per above fixing the table of contents issue

  This also removes the need to workaround autoapi bugs.
- Test doctests in our docs via [`pytest_doctest_docutils`] (built on [`doctest_docutils`])

[`linkify_issues`]: https://gp-libs.git-pull.com/linkify_issues/
[`sphinx_toctree_autodoc_fix`]: https://gp-libs.git-pull.com/sphinx_toctree_autodoc_fix/
[`pytest_doctest_docutils`]: https://gp-libs.git-pull.com/doctest/pytest.html
[`doctest_docutils`]: https://gp-libs.git-pull.com/doctest