### PR TITLE
ci(tests) Verify runtime deps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,15 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
+      - name: Test runtime dependencies
+        run: |
+          uv run --no-dev -p python${{ matrix.python-version }} -- python -c '
+          from unihan_db import bootstrap, importer, tables, __about__, __version__
+          from unihan_etl import __version__ as __unihan_etl_version__
+          print("unihan_db version:", __version__)
+          print("unihan_etl version:", __unihan_etl_version__)
+          '
+
       - name: Install dependencies
         run: uv sync --all-extras --dev
 


### PR DESCRIPTION
## Changes
- Add runtime dependency check in CI using `uv run --no-dev`
- Run check before installing dev dependencies
- Print package version and basic functionality test results
- Document improvement in `CHANGES`

## Summary by Sourcery

Adds a CI check to verify runtime dependencies before installing dev dependencies, including a basic functionality test that prints package versions.

CI:
- Adds a CI check to verify runtime dependencies using `uv run --no-dev` before installing dev dependencies.

Tests:
- Adds a basic functionality test that prints package versions to verify the runtime dependencies.