### PR TITLE
Modernize SQLAlchemy models and fix data-loss bugs

### DIFF
--- a/examples/01_bootstrap.py
+++ b/examples/01_bootstrap.py
@@ -31,7 +31,7 @@ def run(unihan_options: dict[str, object] | None = None) -> None:
 
     assert random_row is not None
 
-    log.info(pprint.pformat(random_row.to_dict()))  # type:ignore
+    log.info(pprint.pformat(random_row.to_dict()))
 
 
 if __name__ == "__main__":

--- a/examples/01_bootstrap.py
+++ b/examples/01_bootstrap.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 import pprint
 
-from sqlalchemy.sql.expression import func
+from sqlalchemy import func, select
 
 from unihan_db import bootstrap
 from unihan_db.tables import Unhn
@@ -21,15 +21,13 @@ def run(unihan_options: dict[str, object] | None = None) -> None:
 
     bootstrap.bootstrap_unihan(session)
 
-    random_row_query = session.query(Unhn).order_by(func.random()).limit(1)
-
-    assert random_row_query is not None
-
-    random_row = random_row_query.first()
-
-    log.info(pprint.pformat(bootstrap.to_dict(random_row)))
+    random_row = session.execute(
+        select(Unhn).order_by(func.random()).limit(1),
+    ).scalar_one_or_none()
 
     assert random_row is not None
+
+    log.info(pprint.pformat(bootstrap.to_dict(random_row)))
 
     log.info(pprint.pformat(random_row.to_dict()))
 

--- a/src/unihan_db/bootstrap.py
+++ b/src/unihan_db/bootstrap.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import logging
 import typing as t
+from collections.abc import Generator
+from contextlib import contextmanager
 
 import sqlalchemy
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, func, select
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
 
 from unihan_etl import core as unihan
@@ -159,8 +161,7 @@ def bootstrap_unihan(
     """Bootstrap UNIHAN to database."""
     options_ = options if options is not None else {}
 
-    """Download, extract and import unihan to database."""
-    if session.query(Unhn).count() == 0:
+    if session.scalar(select(func.count()).select_from(Unhn)) == 0:
         data = bootstrap_data(options_)
         assert data is not None
         log.info("bootstrap Unhn table started")
@@ -240,3 +241,28 @@ def get_session(
     Base.metadata.create_all(bind=engine)
     session_factory = sessionmaker(bind=engine)
     return scoped_session(session_factory)
+
+
+@contextmanager
+def get_session_context(
+    engine_url: str = "sqlite:///{user_data_dir}/unihan_db.db",
+) -> Generator[Session, None, None]:
+    """Return a context-managed SQLAlchemy session.
+
+    Usage::
+
+        with get_session_context() as session:
+            bootstrap_unihan(session)
+            result = session.execute(select(Unhn)).scalars().all()
+
+    Parameters
+    ----------
+    engine_url : str
+        SQLAlchemy engine string
+    """
+    engine_url = engine_url.format(user_data_dir=dirs.user_data_dir)
+    engine = create_engine(engine_url)
+    Base.metadata.create_all(bind=engine)
+
+    with Session(engine) as session:
+        yield session

--- a/src/unihan_db/bootstrap.py
+++ b/src/unihan_db/bootstrap.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 import logging
 import sys
 import typing as t
-from datetime import datetime
 
 import sqlalchemy
-from sqlalchemy import create_engine, event
-from sqlalchemy.orm import Mapper, Session, class_mapper, scoped_session, sessionmaker
-from sqlalchemy.orm.decl_api import registry
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, scoped_session, sessionmaker
 
 from unihan_etl import core as unihan
 from unihan_etl.util import merge_dict
@@ -19,8 +17,6 @@ from . import dirs, importer
 from .tables import Base, Unhn
 
 log = logging.getLogger(__name__)
-
-mapper_reg = registry()
 
 if t.TYPE_CHECKING:
     from sqlalchemy.orm.scoping import ScopedSession
@@ -198,16 +194,10 @@ def bootstrap_unihan(
         log.info("Done adding rows.")
 
 
-@event.listens_for(Unhn, "before_mapper_configured", once=True)
-def setup_orm_mappings(mapper: Mapper[Base], class_: Base) -> None:
-    """Add special methods to Base declarative model used in Unihan DB."""
-    add_to_dict(class_)  # Add .to_dict() to rows returned
-
-
 def to_dict(obj: t.Any, found: set[t.Any] | None = None) -> dict[str, object]:
     """Return dictionary of an SQLAlchemy Query result.
 
-    Supports recursive relationships.
+    Delegates to :meth:`Base.to_dict`. Kept for backward compatibility.
 
     Parameters
     ----------
@@ -221,42 +211,8 @@ def to_dict(obj: t.Any, found: set[t.Any] | None = None) -> dict[str, object]:
     dict :
         dictionary representation of a SQLAlchemy query
     """
-
-    def _get_key_value(c: str) -> t.Any:
-        if isinstance(getattr(obj, c), datetime):
-            return (c, getattr(obj, c).isoformat())
-        return (c, getattr(obj, c))
-
-    found_: set[t.Any]
-
-    found_ = set() if found is None else found
-
-    mapper = class_mapper(obj.__class__)
-    columns = [column.key for column in mapper.columns]
-
-    result = dict(map(_get_key_value, columns))
-    for name, relation in mapper.relationships.items():
-        if relation not in found_:
-            found_.add(relation)
-            related_obj = getattr(obj, name)
-            if related_obj is not None:
-                if relation.uselist:
-                    result[name] = [to_dict(child, found_) for child in related_obj]
-                else:
-                    result[name] = to_dict(related_obj, found_)
+    result: dict[str, object] = obj.to_dict(found)
     return result
-
-
-def add_to_dict(b: t.Any) -> t.Any:
-    """Add :func:`.to_dict` method to SQLAlchemy Base object.
-
-    Parameters
-    ----------
-    b : :func:`~sqlalchemy:sqlalchemy.ext.declarative.declarative_base`
-        SQLAlchemy Base class
-    """
-    b.to_dict = to_dict
-    return b
 
 
 def get_session(

--- a/src/unihan_db/bootstrap.py
+++ b/src/unihan_db/bootstrap.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import sys
 import typing as t
 
 import sqlalchemy
@@ -47,9 +46,6 @@ def setup_logger(
 
         logger.setLevel(level)
         logger.addHandler(channel)
-
-
-setup_logger()
 
 
 UNIHAN_FILES = (
@@ -167,31 +163,39 @@ def bootstrap_unihan(
     if session.query(Unhn).count() == 0:
         data = bootstrap_data(options_)
         assert data is not None
-        log.info("bootstrap Unhn table")
-        log.info("bootstrap Unhn table finished")
-        count = 0
+        log.info("bootstrap Unhn table started")
         total_count = len(data)
         items = []
 
-        for char in data:
+        for count, char in enumerate(data, 1):
             assert isinstance(char, dict)
             c = Unhn(char=char["char"], ucn=char["ucn"])
             importer.import_char(c, char)
             items.append(c)
 
             if log.isEnabledFor(logging.INFO):
-                count += 1
-                sys.stdout.write(
-                    f"\rProcessing {char['char']} ({count} of {total_count})",
+                log.info(
+                    "processing %s (%d of %d)",
+                    char["char"],
+                    count,
+                    total_count,
+                    extra={
+                        "unihan_record_count": count,
+                    },
                 )
-                sys.stdout.flush()
 
-        log.info("Adding rows to database, this could take a minute.")
+        log.info(
+            "adding rows to database",
+            extra={"unihan_db_rows": total_count},
+        )
         session.add_all(items)
         # This takes a bit of time and doesn't provide progress, but it's by
         # far the fastest way to insert as of SQLAlchemy 1.11.
         session.commit()
-        log.info("Done adding rows.")
+        log.info(
+            "bootstrap completed",
+            extra={"unihan_db_rows": total_count},
+        )
 
 
 def to_dict(obj: t.Any, found: set[t.Any] | None = None) -> dict[str, object]:

--- a/src/unihan_db/bootstrap.py
+++ b/src/unihan_db/bootstrap.py
@@ -241,9 +241,9 @@ def to_dict(obj: t.Any, found: set[t.Any] | None = None) -> dict[str, object]:
             related_obj = getattr(obj, name)
             if related_obj is not None:
                 if relation.uselist:
-                    result[name] = [to_dict(child, found) for child in related_obj]
+                    result[name] = [to_dict(child, found_) for child in related_obj]
                 else:
-                    result[name] = to_dict(related_obj, found)
+                    result[name] = to_dict(related_obj, found_)
     return result
 
 

--- a/src/unihan_db/bootstrap.py
+++ b/src/unihan_db/bootstrap.py
@@ -300,3 +300,69 @@ def lookup_char(
         )
     )
     return session.scalar(stmt)
+
+
+def lookup_char_full(
+    session: Session | ScopedSession[t.Any],
+    char: str,
+) -> Unhn | None:
+    """Look up a character with all fields eagerly loaded.
+
+    Loads all relationships via selectinload for comprehensive character
+    data. Use :func:`lookup_char` for lightweight lookups that only need
+    definitions and readings.
+
+    Parameters
+    ----------
+    session : :class:`~sqlalchemy.orm.Session`
+        SQLAlchemy session
+    char : str
+        Single Unicode character to look up
+
+    Returns
+    -------
+    :class:`Unhn` or None
+        The character row with all relationships eagerly loaded, or None.
+    """
+    stmt = (
+        select(Unhn)
+        .where(Unhn.char == char)
+        .options(
+            selectinload(Unhn.kDefinition),
+            selectinload(Unhn.kMandarin),
+            selectinload(Unhn.kCantonese),
+            selectinload(Unhn.kTotalStrokes),
+            selectinload(Unhn.kHanyuPinyin),
+            selectinload(Unhn.kXHC1983),
+            selectinload(Unhn.kCheungBauer),
+            selectinload(Unhn.kRSUnicode),
+            selectinload(Unhn.kRSAdobe_Japan1_6),
+            selectinload(Unhn.kIICore),
+            selectinload(Unhn.kHanYu),
+            selectinload(Unhn.kDaeJaweon),
+            selectinload(Unhn.kIRGHanyuDaZidian),
+            selectinload(Unhn.kIRGDaeJaweon),
+            selectinload(Unhn.kIRGKangXi),
+            selectinload(Unhn.kHDZRadBreak),
+            selectinload(Unhn.kSBGY),
+            selectinload(Unhn.kFenn),
+            selectinload(Unhn.kHanyuPinlu),
+            selectinload(Unhn.kGSR),
+            selectinload(Unhn.kCihaiT),
+            selectinload(Unhn.kCCCII),
+            selectinload(Unhn.kFennIndex),
+            selectinload(Unhn.kCheungBauerIndex),
+            selectinload(Unhn.kIRG_GSource),
+            selectinload(Unhn.kIRG_HSource),
+            selectinload(Unhn.kIRG_JSource),
+            selectinload(Unhn.kIRG_KPSource),
+            selectinload(Unhn.kIRG_KSource),
+            selectinload(Unhn.kIRG_MSource),
+            selectinload(Unhn.kIRG_SSource),
+            selectinload(Unhn.kIRG_TSource),
+            selectinload(Unhn.kIRG_USource),
+            selectinload(Unhn.kIRG_UKSource),
+            selectinload(Unhn.kIRG_VSource),
+        )
+    )
+    return session.scalar(stmt)

--- a/src/unihan_db/bootstrap.py
+++ b/src/unihan_db/bootstrap.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 
 import sqlalchemy
 from sqlalchemy import create_engine, func, select
-from sqlalchemy.orm import Session, scoped_session, sessionmaker
+from sqlalchemy.orm import Session, scoped_session, selectinload, sessionmaker
 
 from unihan_etl import core as unihan
 from unihan_etl.util import merge_dict
@@ -266,3 +266,37 @@ def get_session_context(
 
     with Session(engine) as session:
         yield session
+
+
+def lookup_char(
+    session: Session | ScopedSession[t.Any],
+    char: str,
+) -> Unhn | None:
+    """Look up a character with common fields eagerly loaded.
+
+    Loads kDefinition, kMandarin, kCantonese, and kTotalStrokes via
+    selectinload to prevent N+1 queries for common lookup patterns.
+
+    Parameters
+    ----------
+    session : :class:`~sqlalchemy.orm.Session`
+        SQLAlchemy session
+    char : str
+        Single Unicode character to look up
+
+    Returns
+    -------
+    :class:`Unhn` or None
+        The character row with eagerly loaded fields, or None if not found.
+    """
+    stmt = (
+        select(Unhn)
+        .where(Unhn.char == char)
+        .options(
+            selectinload(Unhn.kDefinition),
+            selectinload(Unhn.kMandarin),
+            selectinload(Unhn.kCantonese),
+            selectinload(Unhn.kTotalStrokes),
+        )
+    )
+    return session.scalar(stmt)

--- a/src/unihan_db/importer.py
+++ b/src/unihan_db/importer.py
@@ -318,7 +318,7 @@ def import_char(
         if f_irg in char:
             irg = char[f_irg]
             assert isinstance(irg, dict)
-            column.append(IRGModel(source=irg["source"], location=irg["location"]))
+            column.append(IRGModel(source=irg["source"], location=irg["location"]))  # type: ignore[arg-type]
 
     if "kGSR" in char:
         for _kgsr in char["kGSR"]:

--- a/src/unihan_db/importer.py
+++ b/src/unihan_db/importer.py
@@ -30,7 +30,9 @@ from unihan_db.tables import (
     kIRG_KPSource,
     kIRG_KSource,
     kIRG_MSource,
+    kIRG_SSource,
     kIRG_TSource,
+    kIRG_UKSource,
     kIRG_USource,
     kIRG_VSource,
     kIRGDaeJaweon,
@@ -305,7 +307,9 @@ def import_char(
         ("kIRG_KPSource", kIRG_KPSource, c.kIRG_KPSource),
         ("kIRG_KSource", kIRG_KSource, c.kIRG_KSource),
         ("kIRG_MSource", kIRG_MSource, c.kIRG_MSource),
+        ("kIRG_SSource", kIRG_SSource, c.kIRG_SSource),
         ("kIRG_TSource", kIRG_TSource, c.kIRG_TSource),
+        ("kIRG_UKSource", kIRG_UKSource, c.kIRG_UKSource),
         ("kIRG_USource", kIRG_USource, c.kIRG_USource),
         ("kIRG_VSource", kIRG_VSource, c.kIRG_VSource),
     )
@@ -348,9 +352,11 @@ def import_char(
         assert isinstance(kFennIndex_["location"], dict)
         c.kFennIndex.append(
             kFennIndex(
-                locations=UnhnLocation(
-                    page=kFennIndex_["location"]["page"],
-                    character=kFennIndex_["location"]["character"],
-                ),
+                locations=[
+                    UnhnLocation(
+                        page=kFennIndex_["location"]["page"],
+                        character=kFennIndex_["location"]["character"],
+                    ),
+                ],
             ),
         )

--- a/src/unihan_db/tables.py
+++ b/src/unihan_db/tables.py
@@ -51,47 +51,122 @@ class Unhn(Base):
         """Return string representation with char and ucn."""
         return f"<Unhn char={self.char!r} ucn={self.ucn!r}>"
 
-    kDefinition: Mapped[list[kDefinition]] = relationship("kDefinition")
-    kCantonese: Mapped[list[kCantonese]] = relationship("kCantonese")
-    kMandarin: Mapped[list[kMandarin]] = relationship("kMandarin")
-    kTotalStrokes: Mapped[list[kTotalStrokes]] = relationship("kTotalStrokes")
+    kDefinition: Mapped[list[kDefinition]] = relationship(
+        back_populates="unhn",
+        cascade="all, delete-orphan",
+    )
+    kCantonese: Mapped[list[kCantonese]] = relationship(
+        back_populates="unhn",
+        cascade="all, delete-orphan",
+    )
+    kMandarin: Mapped[list[kMandarin]] = relationship(
+        back_populates="unhn",
+        cascade="all, delete-orphan",
+    )
+    kTotalStrokes: Mapped[list[kTotalStrokes]] = relationship(
+        back_populates="unhn",
+        cascade="all, delete-orphan",
+    )
     kIRGHanyuDaZidian: Mapped[list[kIRGHanyuDaZidian]] = relationship(
-        "kIRGHanyuDaZidian",
+        cascade="all, delete-orphan",
     )
-    kIRGDaeJaweon: Mapped[list[kIRGDaeJaweon]] = relationship("kIRGDaeJaweon")
-    kIRGKangXi: Mapped[list[kIRGKangXi]] = relationship("kIRGKangXi")
-    kHanyuPinyin: Mapped[list[kHanyuPinyin]] = relationship("kHanyuPinyin")
-    kXHC1983: Mapped[list[kXHC1983]] = relationship("kXHC1983")
-    kCheungBauer: Mapped[list[kCheungBauer]] = relationship("kCheungBauer")
+    kIRGDaeJaweon: Mapped[list[kIRGDaeJaweon]] = relationship(
+        cascade="all, delete-orphan",
+    )
+    kIRGKangXi: Mapped[list[kIRGKangXi]] = relationship(
+        cascade="all, delete-orphan",
+    )
+    kHanyuPinyin: Mapped[list[kHanyuPinyin]] = relationship(
+        cascade="all, delete-orphan",
+    )
+    kXHC1983: Mapped[list[kXHC1983]] = relationship(
+        cascade="all, delete-orphan",
+    )
+    kCheungBauer: Mapped[list[kCheungBauer]] = relationship(
+        cascade="all, delete-orphan",
+    )
     kRSAdobe_Japan1_6: Mapped[list[kRSAdobe_Japan1_6]] = relationship(
-        "kRSAdobe_Japan1_6",
+        back_populates="unhn",
+        cascade="all, delete-orphan",
     )
-    kCihaiT: Mapped[list[kCihaiT]] = relationship("kCihaiT")
-    kIICore: Mapped[list[kIICore]] = relationship("kIICore")
-    kHanYu: Mapped[list[kHanYu]] = relationship("kHanYu")
-    kDaeJaweon: Mapped[list[kDaeJaweon]] = relationship("kDaeJaweon")
-    kFenn: Mapped[list[kFenn]] = relationship("kFenn")
-    kHanyuPinlu: Mapped[list[kHanyuPinlu]] = relationship("kHanyuPinlu")
-    kHDZRadBreak: Mapped[list[kHDZRadBreak]] = relationship("kHDZRadBreak")
-    kSBGY: Mapped[list[kSBGY]] = relationship("kSBGY")
-    kRSUnicode: Mapped[list[kRSUnicode]] = relationship("kRSUnicode")
-    kIRG_GSource: Mapped[list[kIRG_GSource]] = relationship("kIRG_GSource")
-    kIRG_HSource: Mapped[list[kIRG_HSource]] = relationship("kIRG_HSource")
-    kIRG_JSource: Mapped[list[kIRG_JSource]] = relationship("kIRG_JSource")
-    kIRG_KPSource: Mapped[list[kIRG_KPSource]] = relationship("kIRG_KPSource")
-    kIRG_KSource: Mapped[list[kIRG_KSource]] = relationship("kIRG_KSource")
-    kIRG_MSource: Mapped[list[kIRG_MSource]] = relationship("kIRG_MSource")
-    kIRG_SSource: Mapped[list[kIRG_SSource]] = relationship("kIRG_SSource")
-    kIRG_TSource: Mapped[list[kIRG_TSource]] = relationship("kIRG_TSource")
-    kIRG_USource: Mapped[list[kIRG_USource]] = relationship("kIRG_USource")
-    kIRG_UKSource: Mapped[list[kIRG_UKSource]] = relationship("kIRG_UKSource")
-    kIRG_VSource: Mapped[list[kIRG_VSource]] = relationship("kIRG_VSource")
-    kGSR: Mapped[list[kGSR]] = relationship("kGSR")
-    kFennIndex: Mapped[list[kFennIndex]] = relationship("kFennIndex")
+    kCihaiT: Mapped[list[kCihaiT]] = relationship(
+        back_populates="unhn",
+        cascade="all, delete-orphan",
+    )
+    kIICore: Mapped[list[kIICore]] = relationship(
+        back_populates="unhn",
+        cascade="all, delete-orphan",
+    )
+    kHanYu: Mapped[list[kHanYu]] = relationship(
+        cascade="all, delete-orphan",
+    )
+    kDaeJaweon: Mapped[list[kDaeJaweon]] = relationship(
+        cascade="all, delete-orphan",
+    )
+    kFenn: Mapped[list[kFenn]] = relationship(
+        back_populates="unhn",
+        cascade="all, delete-orphan",
+    )
+    kHanyuPinlu: Mapped[list[kHanyuPinlu]] = relationship(
+        back_populates="unhn",
+        cascade="all, delete-orphan",
+    )
+    kHDZRadBreak: Mapped[list[kHDZRadBreak]] = relationship(
+        cascade="all, delete-orphan",
+    )
+    kSBGY: Mapped[list[kSBGY]] = relationship(
+        cascade="all, delete-orphan",
+    )
+    kRSUnicode: Mapped[list[kRSUnicode]] = relationship(
+        cascade="all, delete-orphan",
+    )
+    kIRG_GSource: Mapped[list[kIRG_GSource]] = relationship(
+        cascade="all, delete-orphan",
+    )
+    kIRG_HSource: Mapped[list[kIRG_HSource]] = relationship(
+        cascade="all, delete-orphan",
+    )
+    kIRG_JSource: Mapped[list[kIRG_JSource]] = relationship(
+        cascade="all, delete-orphan",
+    )
+    kIRG_KPSource: Mapped[list[kIRG_KPSource]] = relationship(
+        cascade="all, delete-orphan",
+    )
+    kIRG_KSource: Mapped[list[kIRG_KSource]] = relationship(
+        cascade="all, delete-orphan",
+    )
+    kIRG_MSource: Mapped[list[kIRG_MSource]] = relationship(
+        cascade="all, delete-orphan",
+    )
+    kIRG_SSource: Mapped[list[kIRG_SSource]] = relationship(
+        cascade="all, delete-orphan",
+    )
+    kIRG_TSource: Mapped[list[kIRG_TSource]] = relationship(
+        cascade="all, delete-orphan",
+    )
+    kIRG_USource: Mapped[list[kIRG_USource]] = relationship(
+        cascade="all, delete-orphan",
+    )
+    kIRG_UKSource: Mapped[list[kIRG_UKSource]] = relationship(
+        cascade="all, delete-orphan",
+    )
+    kIRG_VSource: Mapped[list[kIRG_VSource]] = relationship(
+        cascade="all, delete-orphan",
+    )
+    kGSR: Mapped[list[kGSR]] = relationship(
+        back_populates="unhn",
+        cascade="all, delete-orphan",
+    )
+    kFennIndex: Mapped[list[kFennIndex]] = relationship(
+        cascade="all, delete-orphan",
+    )
     kCheungBauerIndex: Mapped[list[kCheungBauerIndex]] = relationship(
-        "kCheungBauerIndex",
+        cascade="all, delete-orphan",
     )
-    kCCCII: Mapped[list[kCCCII]] = relationship("kCCCII")
+    kCCCII: Mapped[list[kCCCII]] = relationship(
+        back_populates="unhn",
+        cascade="all, delete-orphan",
+    )
 
 
 class kCCCII(Base):
@@ -101,6 +176,7 @@ class kCCCII(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
     hex: Mapped[str] = mapped_column(String(6))
+    unhn: Mapped[Unhn] = relationship(back_populates="kCCCII")
 
 
 class GenericIRG(Base):
@@ -219,6 +295,7 @@ class kDefinition(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
     definition: Mapped[str] = mapped_column(String(296))
+    unhn: Mapped[Unhn] = relationship(back_populates="kDefinition")
 
 
 class kCantonese(Base):
@@ -228,6 +305,7 @@ class kCantonese(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
     definition: Mapped[str] = mapped_column(String(128))
+    unhn: Mapped[Unhn] = relationship(back_populates="kCantonese")
 
 
 class kMandarin(Base):
@@ -238,6 +316,7 @@ class kMandarin(Base):
     char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
     hans: Mapped[str] = mapped_column(String(10))
     hant: Mapped[str] = mapped_column(String(10))
+    unhn: Mapped[Unhn] = relationship(back_populates="kMandarin")
 
 
 class kTotalStrokes(Base):
@@ -248,6 +327,7 @@ class kTotalStrokes(Base):
     char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
     hans: Mapped[int] = mapped_column()
     hant: Mapped[int] = mapped_column()
+    unhn: Mapped[Unhn] = relationship(back_populates="kTotalStrokes")
 
 
 class GenericReading(Base):
@@ -261,8 +341,15 @@ class GenericReading(Base):
         index=True,
     )
     type: Mapped[str] = mapped_column(String(50))
-    locations: Mapped[list[UnhnLocation]] = relationship("UnhnLocation")
-    readings: Mapped[list[UnhnReading]] = relationship("UnhnReading")
+    locations: Mapped[list[UnhnLocation]] = relationship(
+        "UnhnLocation",
+        foreign_keys="[UnhnLocation.generic_reading_id]",
+        cascade="all, delete-orphan",
+    )
+    readings: Mapped[list[UnhnReading]] = relationship(
+        "UnhnReading",
+        cascade="all, delete-orphan",
+    )
 
     __mapper_args__ = {  # noqa: RUF012
         "polymorphic_identity": "generic_reading",
@@ -314,6 +401,7 @@ class kRSAdobe_Japan1_6(Base):
     radical: Mapped[int] = mapped_column()
     strokes: Mapped[int] = mapped_column()
     strokes_residue: Mapped[int] = mapped_column()
+    unhn: Mapped[Unhn] = relationship(back_populates="kRSAdobe_Japan1_6")
 
 
 class kHanyuPinyin(GenericReading):
@@ -369,7 +457,11 @@ class GenericIndice(Base):
         index=True,
     )
     type: Mapped[str] = mapped_column(String(50))
-    locations: Mapped[list[UnhnLocation]] = relationship("UnhnLocation")
+    locations: Mapped[list[UnhnLocation]] = relationship(
+        "UnhnLocation",
+        foreign_keys="[UnhnLocation.generic_indice_id]",
+        cascade="all, delete-orphan",
+    )
 
     __mapper_args__ = {  # noqa: RUF012
         "polymorphic_identity": "generic_indice",
@@ -423,6 +515,7 @@ class kCihaiT(Base):
     page: Mapped[int] = mapped_column()
     row: Mapped[int] = mapped_column()
     character: Mapped[int] = mapped_column()
+    unhn: Mapped[Unhn] = relationship(back_populates="kCihaiT")
 
 
 class kIICoreSource(Base):
@@ -432,6 +525,7 @@ class kIICoreSource(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     source_id: Mapped[int] = mapped_column(ForeignKey("kIICore.id"), index=True)
     source: Mapped[str] = mapped_column(String(1))
+    iicore: Mapped[kIICore] = relationship(back_populates="sources")
 
 
 class kIICore(Base):
@@ -441,7 +535,11 @@ class kIICore(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
     priority: Mapped[str] = mapped_column(String(1))
-    sources: Mapped[list[kIICoreSource]] = relationship("kIICoreSource")
+    sources: Mapped[list[kIICoreSource]] = relationship(
+        back_populates="iicore",
+        cascade="all, delete-orphan",
+    )
+    unhn: Mapped[Unhn] = relationship(back_populates="kIICore")
 
 
 class UnhnLocationkXHC1983(Base):
@@ -510,6 +608,7 @@ class kFenn(Base):
     char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
     phonetic: Mapped[str] = mapped_column(String(10))
     frequency: Mapped[str] = mapped_column(String(10))
+    unhn: Mapped[Unhn] = relationship(back_populates="kFenn")
 
 
 class kHanyuPinlu(Base):
@@ -520,6 +619,7 @@ class kHanyuPinlu(Base):
     char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
     phonetic: Mapped[str] = mapped_column(String(10))
     frequency: Mapped[str] = mapped_column(String(10))
+    unhn: Mapped[Unhn] = relationship(back_populates="kHanyuPinlu")
 
 
 class kGSR(Base):
@@ -531,6 +631,7 @@ class kGSR(Base):
     set: Mapped[int] = mapped_column()
     letter: Mapped[str] = mapped_column(String(1))
     apostrophe: Mapped[bool] = mapped_column(Boolean)
+    unhn: Mapped[Unhn] = relationship(back_populates="kGSR")
 
 
 class kHDZRadBreak(GenericIndice):

--- a/src/unihan_db/tables.py
+++ b/src/unihan_db/tables.py
@@ -1,4 +1,3 @@
-# ruff: noqa: RUF012
 """unihan_db table schemas.
 
 Tables are split into general categories, similar to how UNIHAN db's files are:
@@ -24,8 +23,8 @@ joins`_.
 
 from __future__ import annotations
 
-from sqlalchemy import Boolean, Column, ForeignKey, Integer, String
-from sqlalchemy.orm import DeclarativeBase, relationship
+from sqlalchemy import Boolean, ForeignKey, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
 class Base(DeclarativeBase):
@@ -36,53 +35,61 @@ class Unhn(Base):
     """Unhn core table."""
 
     __tablename__ = "Unhn"
-    char = Column(String(1), primary_key=True, index=True, unique=True)
-    ucn = Column(String(8), index=True, unique=True)
+    char: Mapped[str] = mapped_column(
+        String(1), primary_key=True, index=True, unique=True
+    )
+    ucn: Mapped[str] = mapped_column(String(8), index=True, unique=True)
 
-    kDefinition = relationship("kDefinition")
-    kCantonese = relationship("kCantonese")
-    kMandarin = relationship("kMandarin")
-    kTotalStrokes = relationship("kTotalStrokes")
-    kIRGHanyuDaZidian = relationship("kIRGHanyuDaZidian")
-    kIRGDaeJaweon = relationship("kIRGDaeJaweon")
-    kIRGKangXi = relationship("kIRGKangXi")
-    kHanyuPinyin = relationship("kHanyuPinyin")
-    kXHC1983 = relationship("kXHC1983")
-    kCheungBauer = relationship("kCheungBauer")
-    kRSAdobe_Japan1_6 = relationship("kRSAdobe_Japan1_6")
-    kCihaiT = relationship("kCihaiT")
-    kIICore = relationship("kIICore")
-    kHanYu = relationship("kHanYu")
-    kDaeJaweon = relationship("kDaeJaweon")
-    kFenn = relationship("kFenn")
-    kHanyuPinlu = relationship("kHanyuPinlu")
-    kHDZRadBreak = relationship("kHDZRadBreak")
-    kSBGY = relationship("kSBGY")
-    kRSUnicode = relationship("kRSUnicode")
-    kIRG_GSource = relationship("kIRG_GSource")
-    kIRG_HSource = relationship("kIRG_HSource")
-    kIRG_JSource = relationship("kIRG_JSource")
-    kIRG_KPSource = relationship("kIRG_KPSource")
-    kIRG_KSource = relationship("kIRG_KSource")
-    kIRG_MSource = relationship("kIRG_MSource")
-    kIRG_SSource = relationship("kIRG_SSource")
-    kIRG_TSource = relationship("kIRG_TSource")
-    kIRG_USource = relationship("kIRG_USource")
-    kIRG_UKSource = relationship("kIRG_UKSource")
-    kIRG_VSource = relationship("kIRG_VSource")
-    kGSR = relationship("kGSR")
-    kFennIndex = relationship("kFennIndex")
-    kCheungBauerIndex = relationship("kCheungBauerIndex")
-    kCCCII = relationship("kCCCII")
+    kDefinition: Mapped[list[kDefinition]] = relationship("kDefinition")
+    kCantonese: Mapped[list[kCantonese]] = relationship("kCantonese")
+    kMandarin: Mapped[list[kMandarin]] = relationship("kMandarin")
+    kTotalStrokes: Mapped[list[kTotalStrokes]] = relationship("kTotalStrokes")
+    kIRGHanyuDaZidian: Mapped[list[kIRGHanyuDaZidian]] = relationship(
+        "kIRGHanyuDaZidian",
+    )
+    kIRGDaeJaweon: Mapped[list[kIRGDaeJaweon]] = relationship("kIRGDaeJaweon")
+    kIRGKangXi: Mapped[list[kIRGKangXi]] = relationship("kIRGKangXi")
+    kHanyuPinyin: Mapped[list[kHanyuPinyin]] = relationship("kHanyuPinyin")
+    kXHC1983: Mapped[list[kXHC1983]] = relationship("kXHC1983")
+    kCheungBauer: Mapped[list[kCheungBauer]] = relationship("kCheungBauer")
+    kRSAdobe_Japan1_6: Mapped[list[kRSAdobe_Japan1_6]] = relationship(
+        "kRSAdobe_Japan1_6",
+    )
+    kCihaiT: Mapped[list[kCihaiT]] = relationship("kCihaiT")
+    kIICore: Mapped[list[kIICore]] = relationship("kIICore")
+    kHanYu: Mapped[list[kHanYu]] = relationship("kHanYu")
+    kDaeJaweon: Mapped[list[kDaeJaweon]] = relationship("kDaeJaweon")
+    kFenn: Mapped[list[kFenn]] = relationship("kFenn")
+    kHanyuPinlu: Mapped[list[kHanyuPinlu]] = relationship("kHanyuPinlu")
+    kHDZRadBreak: Mapped[list[kHDZRadBreak]] = relationship("kHDZRadBreak")
+    kSBGY: Mapped[list[kSBGY]] = relationship("kSBGY")
+    kRSUnicode: Mapped[list[kRSUnicode]] = relationship("kRSUnicode")
+    kIRG_GSource: Mapped[list[kIRG_GSource]] = relationship("kIRG_GSource")
+    kIRG_HSource: Mapped[list[kIRG_HSource]] = relationship("kIRG_HSource")
+    kIRG_JSource: Mapped[list[kIRG_JSource]] = relationship("kIRG_JSource")
+    kIRG_KPSource: Mapped[list[kIRG_KPSource]] = relationship("kIRG_KPSource")
+    kIRG_KSource: Mapped[list[kIRG_KSource]] = relationship("kIRG_KSource")
+    kIRG_MSource: Mapped[list[kIRG_MSource]] = relationship("kIRG_MSource")
+    kIRG_SSource: Mapped[list[kIRG_SSource]] = relationship("kIRG_SSource")
+    kIRG_TSource: Mapped[list[kIRG_TSource]] = relationship("kIRG_TSource")
+    kIRG_USource: Mapped[list[kIRG_USource]] = relationship("kIRG_USource")
+    kIRG_UKSource: Mapped[list[kIRG_UKSource]] = relationship("kIRG_UKSource")
+    kIRG_VSource: Mapped[list[kIRG_VSource]] = relationship("kIRG_VSource")
+    kGSR: Mapped[list[kGSR]] = relationship("kGSR")
+    kFennIndex: Mapped[list[kFennIndex]] = relationship("kFennIndex")
+    kCheungBauerIndex: Mapped[list[kCheungBauerIndex]] = relationship(
+        "kCheungBauerIndex",
+    )
+    kCCCII: Mapped[list[kCCCII]] = relationship("kCCCII")
 
 
 class kCCCII(Base):
     """Table for kCCCII UNIHAN data."""
 
     __tablename__ = "kCCCII"
-    id = Column(Integer, primary_key=True)
-    char_id = Column(String(1), ForeignKey("Unhn.char"))
-    hex = Column(String(6))
+    id: Mapped[int] = mapped_column(primary_key=True)
+    char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
+    hex: Mapped[str] = mapped_column(String(6))
 
 
 class GenericIRG(Base):
@@ -90,152 +97,163 @@ class GenericIRG(Base):
 
     __tablename__ = "GenericIRG"
 
-    id = Column(Integer, primary_key=True)
-    char_id = Column(String(1), ForeignKey("Unhn.char"))
-    source = Column(Integer)
-    location = Column(String(10), nullable=True)
-    type = Column(String(50))
+    id: Mapped[int] = mapped_column(primary_key=True)
+    char_id: Mapped[str] = mapped_column(
+        String(1),
+        ForeignKey("Unhn.char"),
+        index=True,
+    )
+    source: Mapped[int] = mapped_column()
+    location: Mapped[str | None] = mapped_column(String(10))
+    type: Mapped[str] = mapped_column(String(50))
 
-    __mapper_args__ = {"polymorphic_identity": "generic_irg", "polymorphic_on": "type"}
+    __mapper_args__ = {  # noqa: RUF012
+        "polymorphic_identity": "generic_irg",
+        "polymorphic_on": "type",
+    }
 
 
 class kIRG_GSource(GenericIRG):
     """Table for kIRG_GSource UNIHAN data."""
 
     __tablename__ = "kIRG_GSource"
-    __mapper_args__ = {"polymorphic_identity": "kIRG_GSource"}
-    id = Column(Integer, ForeignKey("GenericIRG.id"), primary_key=True)
+    __mapper_args__ = {"polymorphic_identity": "kIRG_GSource"}  # noqa: RUF012
+    id: Mapped[int] = mapped_column(ForeignKey("GenericIRG.id"), primary_key=True)
 
 
 class kIRG_HSource(GenericIRG):
     """Table for kIRG_HSource UNIHAN data."""
 
     __tablename__ = "kIRG_HSource"
-    __mapper_args__ = {"polymorphic_identity": "kIRG_HSource"}
-    id = Column(Integer, ForeignKey("GenericIRG.id"), primary_key=True)
+    __mapper_args__ = {"polymorphic_identity": "kIRG_HSource"}  # noqa: RUF012
+    id: Mapped[int] = mapped_column(ForeignKey("GenericIRG.id"), primary_key=True)
 
 
 class kIRG_JSource(GenericIRG):
     """Table for kIRG_JSource UNIHAN data."""
 
     __tablename__ = "kIRG_JSource"
-    __mapper_args__ = {"polymorphic_identity": "kIRG_JSource"}
-    id = Column(Integer, ForeignKey("GenericIRG.id"), primary_key=True)
+    __mapper_args__ = {"polymorphic_identity": "kIRG_JSource"}  # noqa: RUF012
+    id: Mapped[int] = mapped_column(ForeignKey("GenericIRG.id"), primary_key=True)
 
 
 class kIRG_KPSource(GenericIRG):
     """Table for kIRG_KPSource UNIHAN data."""
 
     __tablename__ = "kIRG_KPSource"
-    __mapper_args__ = {"polymorphic_identity": "kIRG_KPSource"}
-    id = Column(Integer, ForeignKey("GenericIRG.id"), primary_key=True)
+    __mapper_args__ = {"polymorphic_identity": "kIRG_KPSource"}  # noqa: RUF012
+    id: Mapped[int] = mapped_column(ForeignKey("GenericIRG.id"), primary_key=True)
 
 
 class kIRG_KSource(GenericIRG):
     """Table for kIRG_KSource UNIHAN data."""
 
     __tablename__ = "kIRG_KSource"
-    __mapper_args__ = {"polymorphic_identity": "kIRG_KSource"}
-    id = Column(Integer, ForeignKey("GenericIRG.id"), primary_key=True)
+    __mapper_args__ = {"polymorphic_identity": "kIRG_KSource"}  # noqa: RUF012
+    id: Mapped[int] = mapped_column(ForeignKey("GenericIRG.id"), primary_key=True)
 
 
 class kIRG_MSource(GenericIRG):
     """Table for kIRG_MSource UNIHAN data."""
 
     __tablename__ = "kIRG_MSource"
-    __mapper_args__ = {"polymorphic_identity": "kIRG_MSource"}
-    id = Column(Integer, ForeignKey("GenericIRG.id"), primary_key=True)
+    __mapper_args__ = {"polymorphic_identity": "kIRG_MSource"}  # noqa: RUF012
+    id: Mapped[int] = mapped_column(ForeignKey("GenericIRG.id"), primary_key=True)
 
 
 class kIRG_SSource(GenericIRG):
     """Table for kIRG_SSource UNIHAN data."""
 
     __tablename__ = "kIRG_SSource"
-    __mapper_args__ = {"polymorphic_identity": "kIRG_SSource"}
-    id = Column(Integer, ForeignKey("GenericIRG.id"), primary_key=True)
+    __mapper_args__ = {"polymorphic_identity": "kIRG_SSource"}  # noqa: RUF012
+    id: Mapped[int] = mapped_column(ForeignKey("GenericIRG.id"), primary_key=True)
 
 
 class kIRG_TSource(GenericIRG):
     """Table for kIRG_TSource UNIHAN data."""
 
     __tablename__ = "kIRG_TSource"
-    __mapper_args__ = {"polymorphic_identity": "kIRG_TSource"}
-    id = Column(Integer, ForeignKey("GenericIRG.id"), primary_key=True)
+    __mapper_args__ = {"polymorphic_identity": "kIRG_TSource"}  # noqa: RUF012
+    id: Mapped[int] = mapped_column(ForeignKey("GenericIRG.id"), primary_key=True)
 
 
 class kIRG_USource(GenericIRG):
     """Table for kIRG_USource UNIHAN data."""
 
     __tablename__ = "kIRG_USource"
-    __mapper_args__ = {"polymorphic_identity": "kIRG_USource"}
-    id = Column(Integer, ForeignKey("GenericIRG.id"), primary_key=True)
+    __mapper_args__ = {"polymorphic_identity": "kIRG_USource"}  # noqa: RUF012
+    id: Mapped[int] = mapped_column(ForeignKey("GenericIRG.id"), primary_key=True)
 
 
 class kIRG_UKSource(GenericIRG):
     """Table for kIRG_UKSource UNIHAN data."""
 
     __tablename__ = "kIRG_UKSource"
-    __mapper_args__ = {"polymorphic_identity": "kIRG_UKSource"}
-    id = Column(Integer, ForeignKey("GenericIRG.id"), primary_key=True)
+    __mapper_args__ = {"polymorphic_identity": "kIRG_UKSource"}  # noqa: RUF012
+    id: Mapped[int] = mapped_column(ForeignKey("GenericIRG.id"), primary_key=True)
 
 
 class kIRG_VSource(GenericIRG):
     """Table for kIRG_VSource UNIHAN data."""
 
     __tablename__ = "kIRG_VSource"
-    __mapper_args__ = {"polymorphic_identity": "kIRG_VSource"}
-    id = Column(Integer, ForeignKey("GenericIRG.id"), primary_key=True)
+    __mapper_args__ = {"polymorphic_identity": "kIRG_VSource"}  # noqa: RUF012
+    id: Mapped[int] = mapped_column(ForeignKey("GenericIRG.id"), primary_key=True)
 
 
 class kDefinition(Base):
     """Table for kDefinition UNIHAN data."""
 
     __tablename__ = "kDefinition"
-    id = Column(Integer, primary_key=True)
-    char_id = Column(String(1), ForeignKey("Unhn.char"))
-    definition = Column(String(296))
+    id: Mapped[int] = mapped_column(primary_key=True)
+    char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
+    definition: Mapped[str] = mapped_column(String(296))
 
 
 class kCantonese(Base):
     """Table for kCantonese UNIHAN data."""
 
     __tablename__ = "kCantonese"
-    id = Column(Integer, primary_key=True)
-    char_id = Column(String(1), ForeignKey("Unhn.char"))
-    definition = Column(String(128))
+    id: Mapped[int] = mapped_column(primary_key=True)
+    char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
+    definition: Mapped[str] = mapped_column(String(128))
 
 
 class kMandarin(Base):
     """Table for kManadarin UNIHAN data."""
 
     __tablename__ = "kMandarin"
-    id = Column(Integer, primary_key=True)
-    char_id = Column(String(1), ForeignKey("Unhn.char"))
-    hans = Column(String(10))
-    hant = Column(String(10))
+    id: Mapped[int] = mapped_column(primary_key=True)
+    char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
+    hans: Mapped[str] = mapped_column(String(10))
+    hant: Mapped[str] = mapped_column(String(10))
 
 
 class kTotalStrokes(Base):
     """Table for kTotalStrokes UNIHAN data."""
 
     __tablename__ = "kTotalStrokes"
-    id = Column(Integer, primary_key=True)
-    char_id = Column(String(1), ForeignKey("Unhn.char"))
-    hans = Column(Integer())
-    hant = Column(Integer())
+    id: Mapped[int] = mapped_column(primary_key=True)
+    char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
+    hans: Mapped[int] = mapped_column()
+    hant: Mapped[int] = mapped_column()
 
 
 class GenericReading(Base):
     """Table for GenericReading UNIHAN data."""
 
     __tablename__ = "GenericReading"
-    id = Column(Integer, primary_key=True)
-    char_id = Column(String(1), ForeignKey("Unhn.char"))
-    type = Column(String(50))
-    locations = relationship("UnhnLocation")
-    readings = relationship("UnhnReading")
+    id: Mapped[int] = mapped_column(primary_key=True)
+    char_id: Mapped[str] = mapped_column(
+        String(1),
+        ForeignKey("Unhn.char"),
+        index=True,
+    )
+    type: Mapped[str] = mapped_column(String(50))
+    locations: Mapped[list[UnhnLocation]] = relationship("UnhnLocation")
+    readings: Mapped[list[UnhnReading]] = relationship("UnhnReading")
 
-    __mapper_args__ = {
+    __mapper_args__ = {  # noqa: RUF012
         "polymorphic_identity": "generic_reading",
         "polymorphic_on": "type",
     }
@@ -246,14 +264,18 @@ class GenericRadicalStrokes(Base):
 
     __tablename__ = "GenericRadicalStrokes"
 
-    id = Column(Integer, primary_key=True)
-    char_id = Column(String(1), ForeignKey("Unhn.char"))
-    radical = Column(Integer)
-    strokes = Column(Integer)
-    simplified = Column(String(50), nullable=True)
-    type = Column(String(50))
+    id: Mapped[int] = mapped_column(primary_key=True)
+    char_id: Mapped[str] = mapped_column(
+        String(1),
+        ForeignKey("Unhn.char"),
+        index=True,
+    )
+    radical: Mapped[int] = mapped_column()
+    strokes: Mapped[int] = mapped_column()
+    simplified: Mapped[str | None] = mapped_column(String(50))
+    type: Mapped[str] = mapped_column(String(50))
 
-    __mapper_args__ = {
+    __mapper_args__ = {  # noqa: RUF012
         "polymorphic_identity": "generic_radical_strokes",
         "polymorphic_on": "type",
     }
@@ -263,64 +285,82 @@ class kRSUnicode(GenericRadicalStrokes):
     """Table for kRSUnicode UNIHAN data."""
 
     __tablename__ = "kRSUnicode"
-    __mapper_args__ = {"polymorphic_identity": "kRSUnicode"}
-    id = Column(Integer, ForeignKey("GenericRadicalStrokes.id"), primary_key=True)
+    __mapper_args__ = {"polymorphic_identity": "kRSUnicode"}  # noqa: RUF012
+    id: Mapped[int] = mapped_column(
+        ForeignKey("GenericRadicalStrokes.id"),
+        primary_key=True,
+    )
 
 
 class kRSAdobe_Japan1_6(Base):
     """Table for kRSAdobe_Japan1_6 UNIHAN data."""
 
     __tablename__ = "kRSAdobe_Japan1_6"
-    id = Column(Integer, primary_key=True)
-    char_id = Column(String(1), ForeignKey("Unhn.char"))
-    type = Column(String(1))
-    cid = Column(Integer)
-    radical = Column(Integer)
-    strokes = Column(Integer)
-    strokes_residue = Column(Integer)
+    id: Mapped[int] = mapped_column(primary_key=True)
+    char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
+    type: Mapped[str] = mapped_column(String(1))
+    cid: Mapped[int] = mapped_column()
+    radical: Mapped[int] = mapped_column()
+    strokes: Mapped[int] = mapped_column()
+    strokes_residue: Mapped[int] = mapped_column()
 
 
 class kHanyuPinyin(GenericReading):
     """Table for kHanyuPinyin Unihan data."""
 
     __tablename__ = "kHanyuPinyin"
-    __mapper_args__ = {"polymorphic_identity": "kHanyuPinyin"}
+    __mapper_args__ = {"polymorphic_identity": "kHanyuPinyin"}  # noqa: RUF012
 
-    id = Column(Integer, ForeignKey("GenericReading.id"), primary_key=True)
+    id: Mapped[int] = mapped_column(
+        ForeignKey("GenericReading.id"),
+        primary_key=True,
+    )
 
 
 class kXHC1983(GenericReading):
     """Table for kXHC1983 UNIHAN data."""
 
     __tablename__ = "kXHC1983"
-    __mapper_args__ = {"polymorphic_identity": "kXHC1983"}
+    __mapper_args__ = {"polymorphic_identity": "kXHC1983"}  # noqa: RUF012
 
-    id = Column(Integer, ForeignKey("GenericReading.id"), primary_key=True)
-    locations = relationship("UnhnLocationkXHC1983")
+    id: Mapped[int] = mapped_column(
+        ForeignKey("GenericReading.id"),
+        primary_key=True,
+    )
+    locations: Mapped[list[UnhnLocationkXHC1983]] = relationship(  # type: ignore[assignment]
+        "UnhnLocationkXHC1983",
+    )
 
 
 class kCheungBauer(GenericReading):
     """Table for kCheungBauer UNIHAN data."""
 
     __tablename__ = "kCheungBauer"
-    __mapper_args__ = {"polymorphic_identity": "kCheungBauer"}
+    __mapper_args__ = {"polymorphic_identity": "kCheungBauer"}  # noqa: RUF012
 
-    id = Column(Integer, ForeignKey("GenericReading.id"), primary_key=True)
-    radical = Column(Integer)
-    strokes = Column(Integer)
-    cangjie = Column(String, nullable=True)
+    id: Mapped[int] = mapped_column(
+        ForeignKey("GenericReading.id"),
+        primary_key=True,
+    )
+    radical: Mapped[int] = mapped_column()
+    strokes: Mapped[int] = mapped_column()
+    cangjie: Mapped[str | None] = mapped_column(String)
 
 
 class GenericIndice(Base):
     """Table for GenericIndice UNIHAN data."""
 
     __tablename__ = "GenericIndice"
-    id = Column(Integer, primary_key=True)
-    char_id = Column(String(1), ForeignKey("Unhn.char"))
-    type = Column(String(50))
-    locations = relationship("UnhnLocation")
+    id: Mapped[int] = mapped_column(primary_key=True)
+    char_id: Mapped[str] = mapped_column(
+        String(1),
+        ForeignKey("Unhn.char"),
+        index=True,
+    )
+    type: Mapped[str] = mapped_column(String(50))
+    locations: Mapped[list[UnhnLocation]] = relationship("UnhnLocation")
 
-    __mapper_args__ = {
+    __mapper_args__ = {  # noqa: RUF012
         "polymorphic_identity": "generic_indice",
         "polymorphic_on": "type",
     }
@@ -330,176 +370,191 @@ class kHanYu(GenericIndice):
     """Table for kHanYu UNIHAN data."""
 
     __tablename__ = "kHanYu"
-    __mapper_args__ = {"polymorphic_identity": "kHanYu"}
+    __mapper_args__ = {"polymorphic_identity": "kHanYu"}  # noqa: RUF012
 
-    id = Column(Integer, ForeignKey("GenericIndice.id"), primary_key=True)
+    id: Mapped[int] = mapped_column(ForeignKey("GenericIndice.id"), primary_key=True)
 
 
 class kIRGHanyuDaZidian(GenericIndice):
     """Table for kIRGHanyuDaZidian UNIHAN data."""
 
     __tablename__ = "kIRGHanyuDaZidian"
-    __mapper_args__ = {"polymorphic_identity": "kIRGHanyuDaZidian"}
+    __mapper_args__ = {"polymorphic_identity": "kIRGHanyuDaZidian"}  # noqa: RUF012
 
-    id = Column(Integer, ForeignKey("GenericIndice.id"), primary_key=True)
+    id: Mapped[int] = mapped_column(ForeignKey("GenericIndice.id"), primary_key=True)
 
 
 class UnhnLocation(Base):
     """Table for UnhnLocation UNIHAN data."""
 
     __tablename__ = "UnhnLocation"
-    id = Column(Integer, primary_key=True)
-    generic_reading_id = Column(Integer, ForeignKey("GenericReading.id"))
-    generic_indice_id = Column(Integer, ForeignKey("GenericIndice.id"))
-    volume = Column(Integer, nullable=True)
-    page = Column(Integer)
-    character = Column(Integer)
-    virtual = Column(Integer, nullable=True)
+    id: Mapped[int] = mapped_column(primary_key=True)
+    generic_reading_id: Mapped[int | None] = mapped_column(
+        ForeignKey("GenericReading.id"),
+        index=True,
+    )
+    generic_indice_id: Mapped[int | None] = mapped_column(
+        ForeignKey("GenericIndice.id"),
+        index=True,
+    )
+    volume: Mapped[int | None] = mapped_column()
+    page: Mapped[int] = mapped_column()
+    character: Mapped[int] = mapped_column()
+    virtual: Mapped[bool | None] = mapped_column(Boolean)
 
 
 class kCihaiT(Base):
     """Table for kCihaiT UNIHAN data."""
 
     __tablename__ = "UnhnLocationkCihaiT"
-    id = Column(Integer, primary_key=True)
-    char_id = Column(String(1), ForeignKey("Unhn.char"))
-    page = Column(Integer)
-    row = Column(Integer)
-    character = Column(Integer)
+    id: Mapped[int] = mapped_column(primary_key=True)
+    char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
+    page: Mapped[int] = mapped_column()
+    row: Mapped[int] = mapped_column()
+    character: Mapped[int] = mapped_column()
 
 
 class kIICoreSource(Base):
     """Table for kIICoreSource UIHAN data."""
 
     __tablename__ = "kIICoreSource"
-    id = Column(Integer, primary_key=True)
-    source_id = Column(Integer, ForeignKey("kIICore.id"))
-    source = Column(String(1))
+    id: Mapped[int] = mapped_column(primary_key=True)
+    source_id: Mapped[int] = mapped_column(ForeignKey("kIICore.id"), index=True)
+    source: Mapped[str] = mapped_column(String(1))
 
 
 class kIICore(Base):
     """Table for kIICore UNIHAN data."""
 
     __tablename__ = "kIICore"
-    id = Column(Integer, primary_key=True)
-    char_id = Column(String(1), ForeignKey("Unhn.char"))
-    priority = Column(String(1))
-    sources = relationship("kIICoreSource")
+    id: Mapped[int] = mapped_column(primary_key=True)
+    char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
+    priority: Mapped[str] = mapped_column(String(1))
+    sources: Mapped[list[kIICoreSource]] = relationship("kIICoreSource")
 
 
 class UnhnLocationkXHC1983(Base):
     """Table for UnhnLocationkXHC1983 UNIHAN data."""
 
     __tablename__ = "UnhnLocationkXHC1983"
-    id = Column(Integer, primary_key=True)
-    generic_reading_id = Column(Integer, ForeignKey("GenericReading.id"))
-    generic_indice_id = Column(Integer, ForeignKey("GenericIndice.id"))
-    page = Column(Integer)
-    character = Column(Integer)
-    entry = Column(Integer)
-    substituted = Column(Boolean)
+    id: Mapped[int] = mapped_column(primary_key=True)
+    generic_reading_id: Mapped[int | None] = mapped_column(
+        ForeignKey("GenericReading.id"),
+        index=True,
+    )
+    generic_indice_id: Mapped[int | None] = mapped_column(
+        ForeignKey("GenericIndice.id"),
+        index=True,
+    )
+    page: Mapped[int] = mapped_column()
+    character: Mapped[int] = mapped_column()
+    entry: Mapped[int] = mapped_column()
+    substituted: Mapped[bool] = mapped_column(Boolean)
 
 
 class UnhnReading(Base):
     """Table for UnhnReading UNIHAN data."""
 
     __tablename__ = "UnhnReading"
-    id = Column(Integer, primary_key=True)
-    generic_reading_id = Column(Integer, ForeignKey("GenericReading.id"))
-    reading = Column(String(24))
+    id: Mapped[int] = mapped_column(primary_key=True)
+    generic_reading_id: Mapped[int] = mapped_column(
+        ForeignKey("GenericReading.id"),
+        index=True,
+    )
+    reading: Mapped[str] = mapped_column(String(24))
 
 
 class kDaeJaweon(GenericIndice):
     """Table for kDaewJaweon UNIHAN data."""
 
     __tablename__ = "kDaeJaweon"
-    __mapper_args__ = {"polymorphic_identity": "kDaeJaweon"}
+    __mapper_args__ = {"polymorphic_identity": "kDaeJaweon"}  # noqa: RUF012
 
-    id = Column(Integer, ForeignKey("GenericIndice.id"), primary_key=True)
+    id: Mapped[int] = mapped_column(ForeignKey("GenericIndice.id"), primary_key=True)
 
 
 class kIRGKangXi(GenericIndice):
     """Table for kIRGKangXi UNIHAN data."""
 
     __tablename__ = "kIRGKangXi"
-    __mapper_args__ = {"polymorphic_identity": "kIRGKangXi"}
+    __mapper_args__ = {"polymorphic_identity": "kIRGKangXi"}  # noqa: RUF012
 
-    id = Column(Integer, ForeignKey("GenericIndice.id"), primary_key=True)
+    id: Mapped[int] = mapped_column(ForeignKey("GenericIndice.id"), primary_key=True)
 
 
 class kIRGDaeJaweon(GenericIndice):
     """Table for kIRGDaeJaweon UNIHAN data."""
 
     __tablename__ = "kIRGDaeJaweon"
-    __mapper_args__ = {"polymorphic_identity": "kIRGDaeJaweon"}
+    __mapper_args__ = {"polymorphic_identity": "kIRGDaeJaweon"}  # noqa: RUF012
 
-    id = Column(Integer, ForeignKey("GenericIndice.id"), primary_key=True)
+    id: Mapped[int] = mapped_column(ForeignKey("GenericIndice.id"), primary_key=True)
 
 
 class kFenn(Base):
     """Table for kFenn UNIHAN data."""
 
     __tablename__ = "kFenn"
-    id = Column(Integer, primary_key=True)
-    char_id = Column(String(1), ForeignKey("Unhn.char"))
-    phonetic = Column(String(10))
-    frequency = Column(String(10))
+    id: Mapped[int] = mapped_column(primary_key=True)
+    char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
+    phonetic: Mapped[str] = mapped_column(String(10))
+    frequency: Mapped[str] = mapped_column(String(10))
 
 
 class kHanyuPinlu(Base):
     """Table for kHanyuPinlu UNIHAN data."""
 
     __tablename__ = "kHanyuPinlu"
-    id = Column(Integer, primary_key=True)
-    char_id = Column(String(1), ForeignKey("Unhn.char"))
-    phonetic = Column(String(10))
-    frequency = Column(String(10))
+    id: Mapped[int] = mapped_column(primary_key=True)
+    char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
+    phonetic: Mapped[str] = mapped_column(String(10))
+    frequency: Mapped[str] = mapped_column(String(10))
 
 
 class kGSR(Base):
     """Table for kGSR UNIHAN data."""
 
     __tablename__ = "kGSR"
-    id = Column(Integer, primary_key=True)
-    char_id = Column(String(1), ForeignKey("Unhn.char"))
-    set = Column(Integer)
-    letter = Column(String(1))
-    apostrophe = Column(Boolean)
+    id: Mapped[int] = mapped_column(primary_key=True)
+    char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
+    set: Mapped[int] = mapped_column()
+    letter: Mapped[str] = mapped_column(String(1))
+    apostrophe: Mapped[bool] = mapped_column(Boolean)
 
 
 class kHDZRadBreak(GenericIndice):
     """Table for kHDZRadBreak UNIHAN data."""
 
     __tablename__ = "kHDZRadBreak"
-    __mapper_args__ = {"polymorphic_identity": "kHDZRadBreak"}
+    __mapper_args__ = {"polymorphic_identity": "kHDZRadBreak"}  # noqa: RUF012
 
-    id = Column(Integer, ForeignKey("GenericIndice.id"), primary_key=True)
-    radical = Column(String(10))
-    ucn = Column(String(10))
+    id: Mapped[int] = mapped_column(ForeignKey("GenericIndice.id"), primary_key=True)
+    radical: Mapped[str] = mapped_column(String(10))
+    ucn: Mapped[str] = mapped_column(String(10))
 
 
 class kSBGY(GenericIndice):
     """Table for kSBGY UNIHAN data."""
 
     __tablename__ = "kSBGY"
-    __mapper_args__ = {"polymorphic_identity": "kSBGY"}
+    __mapper_args__ = {"polymorphic_identity": "kSBGY"}  # noqa: RUF012
 
-    id = Column(Integer, ForeignKey("GenericIndice.id"), primary_key=True)
+    id: Mapped[int] = mapped_column(ForeignKey("GenericIndice.id"), primary_key=True)
 
 
 class kCheungBauerIndex(GenericIndice):
     """Table for kCheungBauerIndex UNIHAN data."""
 
     __tablename__ = "kCheungBauerIndex"
-    __mapper_args__ = {"polymorphic_identity": "kCheungBauerIndex"}
+    __mapper_args__ = {"polymorphic_identity": "kCheungBauerIndex"}  # noqa: RUF012
 
-    id = Column(Integer, ForeignKey("GenericIndice.id"), primary_key=True)
+    id: Mapped[int] = mapped_column(ForeignKey("GenericIndice.id"), primary_key=True)
 
 
 class kFennIndex(GenericIndice):
     """Table for kFennIndex UNIHAN data."""
 
     __tablename__ = "kFennIndex"
-    __mapper_args__ = {"polymorphic_identity": "kFennIndex"}
+    __mapper_args__ = {"polymorphic_identity": "kFennIndex"}  # noqa: RUF012
 
-    id = Column(Integer, ForeignKey("GenericIndice.id"), primary_key=True)
+    id: Mapped[int] = mapped_column(ForeignKey("GenericIndice.id"), primary_key=True)

--- a/src/unihan_db/tables.py
+++ b/src/unihan_db/tables.py
@@ -36,6 +36,7 @@ from sqlalchemy import (
     inspect as sa_inspect,
     select as sa_select,
 )
+from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import (
     DeclarativeBase,
@@ -443,6 +444,10 @@ class GenericReading(Base):
     readings: Mapped[list[UnhnReading]] = relationship(
         "UnhnReading",
         cascade="all, delete-orphan",
+    )
+    reading_strings: AssociationProxy[list[str]] = association_proxy(
+        "readings",
+        "reading",
     )
 
     __mapper_args__ = {  # noqa: RUF012

--- a/src/unihan_db/tables.py
+++ b/src/unihan_db/tables.py
@@ -23,8 +23,17 @@ joins`_.
 
 from __future__ import annotations
 
+import typing as t
+from datetime import datetime
+
 from sqlalchemy import Boolean, ForeignKey, String, inspect as sa_inspect
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    class_mapper,
+    mapped_column,
+    relationship,
+)
 
 
 class Base(DeclarativeBase):
@@ -36,6 +45,45 @@ class Base(DeclarativeBase):
         pk_cols = [col.key for col in mapper.primary_key if col.key is not None]
         attrs = ", ".join(f"{k}={getattr(self, k)!r}" for k in pk_cols)
         return f"<{self.__class__.__name__} {attrs}>"
+
+    def to_dict(self, found: set[t.Any] | None = None) -> dict[str, object]:
+        """Return dictionary representation of this ORM object.
+
+        Supports recursive relationships.
+
+        Parameters
+        ----------
+        found : set, optional
+            Tracks visited relationships to prevent infinite recursion.
+
+        Returns
+        -------
+        dict :
+            Dictionary representation including columns and relationships.
+        """
+
+        def _get_key_value(c: str) -> tuple[str, object]:
+            val = getattr(self, c)
+            if isinstance(val, datetime):
+                return (c, val.isoformat())
+            return (c, val)
+
+        found_ = set() if found is None else found
+
+        mapper = class_mapper(self.__class__)
+        columns = [column.key for column in mapper.columns]
+
+        result = dict(map(_get_key_value, columns))
+        for name, relation in mapper.relationships.items():
+            if relation not in found_:
+                found_.add(relation)
+                related_obj = getattr(self, name)
+                if related_obj is not None:
+                    if relation.uselist:
+                        result[name] = [child.to_dict(found_) for child in related_obj]
+                    else:
+                        result[name] = related_obj.to_dict(found_)
+        return result
 
 
 class Unhn(Base):

--- a/src/unihan_db/tables.py
+++ b/src/unihan_db/tables.py
@@ -23,12 +23,19 @@ joins`_.
 
 from __future__ import annotations
 
-from sqlalchemy import Boolean, ForeignKey, String
+from sqlalchemy import Boolean, ForeignKey, String, inspect as sa_inspect
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
 class Base(DeclarativeBase):
     """SQLAlchemy Declarative base class for UNIHAN DB."""
+
+    def __repr__(self) -> str:
+        """Return string representation with primary key columns."""
+        mapper = sa_inspect(self.__class__)
+        pk_cols = [col.key for col in mapper.primary_key if col.key is not None]
+        attrs = ", ".join(f"{k}={getattr(self, k)!r}" for k in pk_cols)
+        return f"<{self.__class__.__name__} {attrs}>"
 
 
 class Unhn(Base):
@@ -39,6 +46,10 @@ class Unhn(Base):
         String(1), primary_key=True, index=True, unique=True
     )
     ucn: Mapped[str] = mapped_column(String(8), index=True, unique=True)
+
+    def __repr__(self) -> str:
+        """Return string representation with char and ucn."""
+        return f"<Unhn char={self.char!r} ucn={self.ucn!r}>"
 
     kDefinition: Mapped[list[kDefinition]] = relationship("kDefinition")
     kCantonese: Mapped[list[kCantonese]] = relationship("kCantonese")

--- a/src/unihan_db/tables.py
+++ b/src/unihan_db/tables.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import typing as t
 from datetime import datetime
+from typing import Annotated
 
 from sqlalchemy import Boolean, ForeignKey, String, inspect as sa_inspect
 from sqlalchemy.orm import (
@@ -34,6 +35,9 @@ from sqlalchemy.orm import (
     mapped_column,
     relationship,
 )
+
+intpk = Annotated[int, mapped_column(primary_key=True)]
+char_fk = Annotated[str, mapped_column(String(1), ForeignKey("Unhn.char"), index=True)]
 
 
 class Base(DeclarativeBase):
@@ -221,8 +225,8 @@ class kCCCII(Base):
     """Table for kCCCII UNIHAN data."""
 
     __tablename__ = "kCCCII"
-    id: Mapped[int] = mapped_column(primary_key=True)
-    char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
+    id: Mapped[intpk]
+    char_id: Mapped[char_fk]
     hex: Mapped[str] = mapped_column(String(6))
     unhn: Mapped[Unhn] = relationship(back_populates="kCCCII")
 
@@ -232,12 +236,8 @@ class GenericIRG(Base):
 
     __tablename__ = "GenericIRG"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
-    char_id: Mapped[str] = mapped_column(
-        String(1),
-        ForeignKey("Unhn.char"),
-        index=True,
-    )
+    id: Mapped[intpk]
+    char_id: Mapped[char_fk]
     source: Mapped[int] = mapped_column()
     location: Mapped[str | None] = mapped_column(String(10))
     type: Mapped[str] = mapped_column(String(50))
@@ -340,8 +340,8 @@ class kDefinition(Base):
     """Table for kDefinition UNIHAN data."""
 
     __tablename__ = "kDefinition"
-    id: Mapped[int] = mapped_column(primary_key=True)
-    char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
+    id: Mapped[intpk]
+    char_id: Mapped[char_fk]
     definition: Mapped[str] = mapped_column(String(296))
     unhn: Mapped[Unhn] = relationship(back_populates="kDefinition")
 
@@ -350,8 +350,8 @@ class kCantonese(Base):
     """Table for kCantonese UNIHAN data."""
 
     __tablename__ = "kCantonese"
-    id: Mapped[int] = mapped_column(primary_key=True)
-    char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
+    id: Mapped[intpk]
+    char_id: Mapped[char_fk]
     definition: Mapped[str] = mapped_column(String(128))
     unhn: Mapped[Unhn] = relationship(back_populates="kCantonese")
 
@@ -360,8 +360,8 @@ class kMandarin(Base):
     """Table for kManadarin UNIHAN data."""
 
     __tablename__ = "kMandarin"
-    id: Mapped[int] = mapped_column(primary_key=True)
-    char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
+    id: Mapped[intpk]
+    char_id: Mapped[char_fk]
     hans: Mapped[str] = mapped_column(String(10))
     hant: Mapped[str] = mapped_column(String(10))
     unhn: Mapped[Unhn] = relationship(back_populates="kMandarin")
@@ -371,8 +371,8 @@ class kTotalStrokes(Base):
     """Table for kTotalStrokes UNIHAN data."""
 
     __tablename__ = "kTotalStrokes"
-    id: Mapped[int] = mapped_column(primary_key=True)
-    char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
+    id: Mapped[intpk]
+    char_id: Mapped[char_fk]
     hans: Mapped[int] = mapped_column()
     hant: Mapped[int] = mapped_column()
     unhn: Mapped[Unhn] = relationship(back_populates="kTotalStrokes")
@@ -382,12 +382,8 @@ class GenericReading(Base):
     """Table for GenericReading UNIHAN data."""
 
     __tablename__ = "GenericReading"
-    id: Mapped[int] = mapped_column(primary_key=True)
-    char_id: Mapped[str] = mapped_column(
-        String(1),
-        ForeignKey("Unhn.char"),
-        index=True,
-    )
+    id: Mapped[intpk]
+    char_id: Mapped[char_fk]
     type: Mapped[str] = mapped_column(String(50))
     locations: Mapped[list[UnhnLocation]] = relationship(
         "UnhnLocation",
@@ -410,12 +406,8 @@ class GenericRadicalStrokes(Base):
 
     __tablename__ = "GenericRadicalStrokes"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
-    char_id: Mapped[str] = mapped_column(
-        String(1),
-        ForeignKey("Unhn.char"),
-        index=True,
-    )
+    id: Mapped[intpk]
+    char_id: Mapped[char_fk]
     radical: Mapped[int] = mapped_column()
     strokes: Mapped[int] = mapped_column()
     simplified: Mapped[str | None] = mapped_column(String(50))
@@ -442,8 +434,8 @@ class kRSAdobe_Japan1_6(Base):
     """Table for kRSAdobe_Japan1_6 UNIHAN data."""
 
     __tablename__ = "kRSAdobe_Japan1_6"
-    id: Mapped[int] = mapped_column(primary_key=True)
-    char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
+    id: Mapped[intpk]
+    char_id: Mapped[char_fk]
     type: Mapped[str] = mapped_column(String(1))
     cid: Mapped[int] = mapped_column()
     radical: Mapped[int] = mapped_column()
@@ -498,12 +490,8 @@ class GenericIndice(Base):
     """Table for GenericIndice UNIHAN data."""
 
     __tablename__ = "GenericIndice"
-    id: Mapped[int] = mapped_column(primary_key=True)
-    char_id: Mapped[str] = mapped_column(
-        String(1),
-        ForeignKey("Unhn.char"),
-        index=True,
-    )
+    id: Mapped[intpk]
+    char_id: Mapped[char_fk]
     type: Mapped[str] = mapped_column(String(50))
     locations: Mapped[list[UnhnLocation]] = relationship(
         "UnhnLocation",
@@ -539,7 +527,7 @@ class UnhnLocation(Base):
     """Table for UnhnLocation UNIHAN data."""
 
     __tablename__ = "UnhnLocation"
-    id: Mapped[int] = mapped_column(primary_key=True)
+    id: Mapped[intpk]
     generic_reading_id: Mapped[int | None] = mapped_column(
         ForeignKey("GenericReading.id"),
         index=True,
@@ -558,8 +546,8 @@ class kCihaiT(Base):
     """Table for kCihaiT UNIHAN data."""
 
     __tablename__ = "UnhnLocationkCihaiT"
-    id: Mapped[int] = mapped_column(primary_key=True)
-    char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
+    id: Mapped[intpk]
+    char_id: Mapped[char_fk]
     page: Mapped[int] = mapped_column()
     row: Mapped[int] = mapped_column()
     character: Mapped[int] = mapped_column()
@@ -570,7 +558,7 @@ class kIICoreSource(Base):
     """Table for kIICoreSource UIHAN data."""
 
     __tablename__ = "kIICoreSource"
-    id: Mapped[int] = mapped_column(primary_key=True)
+    id: Mapped[intpk]
     source_id: Mapped[int] = mapped_column(ForeignKey("kIICore.id"), index=True)
     source: Mapped[str] = mapped_column(String(1))
     iicore: Mapped[kIICore] = relationship(back_populates="sources")
@@ -580,8 +568,8 @@ class kIICore(Base):
     """Table for kIICore UNIHAN data."""
 
     __tablename__ = "kIICore"
-    id: Mapped[int] = mapped_column(primary_key=True)
-    char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
+    id: Mapped[intpk]
+    char_id: Mapped[char_fk]
     priority: Mapped[str] = mapped_column(String(1))
     sources: Mapped[list[kIICoreSource]] = relationship(
         back_populates="iicore",
@@ -594,7 +582,7 @@ class UnhnLocationkXHC1983(Base):
     """Table for UnhnLocationkXHC1983 UNIHAN data."""
 
     __tablename__ = "UnhnLocationkXHC1983"
-    id: Mapped[int] = mapped_column(primary_key=True)
+    id: Mapped[intpk]
     generic_reading_id: Mapped[int | None] = mapped_column(
         ForeignKey("GenericReading.id"),
         index=True,
@@ -613,7 +601,7 @@ class UnhnReading(Base):
     """Table for UnhnReading UNIHAN data."""
 
     __tablename__ = "UnhnReading"
-    id: Mapped[int] = mapped_column(primary_key=True)
+    id: Mapped[intpk]
     generic_reading_id: Mapped[int] = mapped_column(
         ForeignKey("GenericReading.id"),
         index=True,
@@ -652,8 +640,8 @@ class kFenn(Base):
     """Table for kFenn UNIHAN data."""
 
     __tablename__ = "kFenn"
-    id: Mapped[int] = mapped_column(primary_key=True)
-    char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
+    id: Mapped[intpk]
+    char_id: Mapped[char_fk]
     phonetic: Mapped[str] = mapped_column(String(10))
     frequency: Mapped[str] = mapped_column(String(10))
     unhn: Mapped[Unhn] = relationship(back_populates="kFenn")
@@ -663,8 +651,8 @@ class kHanyuPinlu(Base):
     """Table for kHanyuPinlu UNIHAN data."""
 
     __tablename__ = "kHanyuPinlu"
-    id: Mapped[int] = mapped_column(primary_key=True)
-    char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
+    id: Mapped[intpk]
+    char_id: Mapped[char_fk]
     phonetic: Mapped[str] = mapped_column(String(10))
     frequency: Mapped[str] = mapped_column(String(10))
     unhn: Mapped[Unhn] = relationship(back_populates="kHanyuPinlu")
@@ -674,8 +662,8 @@ class kGSR(Base):
     """Table for kGSR UNIHAN data."""
 
     __tablename__ = "kGSR"
-    id: Mapped[int] = mapped_column(primary_key=True)
-    char_id: Mapped[str] = mapped_column(String(1), ForeignKey("Unhn.char"), index=True)
+    id: Mapped[intpk]
+    char_id: Mapped[char_fk]
     set: Mapped[int] = mapped_column()
     letter: Mapped[str] = mapped_column(String(1))
     apostrophe: Mapped[bool] = mapped_column(Boolean)

--- a/src/unihan_db/tables.py
+++ b/src/unihan_db/tables.py
@@ -27,11 +27,21 @@ import typing as t
 from datetime import datetime
 from typing import Annotated
 
-from sqlalchemy import Boolean, ForeignKey, String, inspect as sa_inspect
+from sqlalchemy import (
+    Boolean,
+    ForeignKey,
+    String,
+    exists,
+    func,
+    inspect as sa_inspect,
+    select as sa_select,
+)
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import (
     DeclarativeBase,
     Mapped,
     class_mapper,
+    column_property,
     mapped_column,
     relationship,
 )
@@ -102,6 +112,37 @@ class Unhn(Base):
     def __repr__(self) -> str:
         """Return string representation with char and ucn."""
         return f"<Unhn char={self.char!r} ucn={self.ucn!r}>"
+
+    @hybrid_property
+    def has_definition(self) -> bool:
+        """Return True if this character has at least one definition."""
+        return len(self.kDefinition) > 0
+
+    @has_definition.inplace.expression
+    @classmethod
+    def _has_definition_expression(cls) -> t.Any:
+        return exists().where(kDefinition.char_id == cls.char)
+
+    @hybrid_property
+    def definition_text(self) -> str | None:
+        """Return the first definition text, or None."""
+        if self.kDefinition:
+            return self.kDefinition[0].definition
+        return None
+
+    @definition_text.inplace.expression
+    @classmethod
+    def _definition_text_expression(cls) -> t.Any:
+        return (
+            sa_select(kDefinition.definition)
+            .where(kDefinition.char_id == cls.char)
+            .limit(1)
+            .correlate(cls)
+            .scalar_subquery()
+        )
+
+    if t.TYPE_CHECKING:
+        definition_count: Mapped[int]
 
     kDefinition: Mapped[list[kDefinition]] = relationship(
         back_populates="unhn",
@@ -344,6 +385,15 @@ class kDefinition(Base):
     char_id: Mapped[char_fk]
     definition: Mapped[str] = mapped_column(String(296))
     unhn: Mapped[Unhn] = relationship(back_populates="kDefinition")
+
+
+Unhn.definition_count = column_property(
+    sa_select(func.count(kDefinition.id))
+    .where(kDefinition.char_id == Unhn.char)
+    .correlate_except(kDefinition)
+    .scalar_subquery(),
+    deferred=True,
+)
 
 
 class kCantonese(Base):

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -7,7 +7,7 @@ import typing as t
 from sqlalchemy import func, select
 
 from unihan_db import bootstrap
-from unihan_db.tables import Base, Unhn, kDefinition
+from unihan_db.tables import Base, Unhn, UnhnReading, kDefinition, kHanyuPinyin
 
 if t.TYPE_CHECKING:
     import pathlib
@@ -167,3 +167,37 @@ def test_definition_count(session: Session, engine: sqlalchemy.Engine) -> None:
 
     session.expire(char)
     assert char.definition_count == 2
+
+
+def test_reading_strings_proxy(
+    session: Session,
+    engine: sqlalchemy.Engine,
+) -> None:
+    """Test reading_strings association proxy on GenericReading."""
+    Base.metadata.create_all(engine)
+    char = Unhn(char="月", ucn="U+6708")
+    khp = kHanyuPinyin(
+        readings=[UnhnReading(reading="yue4")],
+    )
+    char.kHanyuPinyin.append(khp)
+    session.add(char)
+    session.commit()
+
+    assert khp.reading_strings == ["yue4"]
+
+
+def test_lookup_char_full(
+    zip_file: object,
+    session: Session,
+    engine: sqlalchemy.Engine,
+    unihan_options: UnihanOptions,
+) -> None:
+    """Test lookup_char_full() returns character with all relationships."""
+    Base.metadata.create_all(bind=engine)
+    bootstrap.bootstrap_unihan(session, unihan_options)
+    session.commit()
+
+    result = bootstrap.lookup_char_full(session, "好")
+    if result is not None:
+        assert result.char == "好"
+        assert isinstance(result.kDefinition, list)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -110,3 +110,60 @@ def test_to_dict_compat(session: Session, engine: sqlalchemy.Engine) -> None:
     result = bootstrap.to_dict(char)
     assert result["char"] == "天"
     assert result["ucn"] == "U+5929"
+
+
+def test_has_definition_python(session: Session, engine: sqlalchemy.Engine) -> None:
+    """Test has_definition hybrid_property at Python level."""
+    Base.metadata.create_all(engine)
+    with_def = Unhn(char="水", ucn="U+6C34")
+    with_def.kDefinition.append(kDefinition(definition="water"))
+    without_def = Unhn(char="火", ucn="U+706B")
+    session.add_all([with_def, without_def])
+    session.commit()
+
+    assert with_def.has_definition is True
+    assert without_def.has_definition is False
+
+
+def test_has_definition_sql(session: Session, engine: sqlalchemy.Engine) -> None:
+    """Test has_definition hybrid_property in SQL WHERE clause."""
+    Base.metadata.create_all(engine)
+    with_def = Unhn(char="金", ucn="U+91D1")
+    with_def.kDefinition.append(kDefinition(definition="gold"))
+    without_def = Unhn(char="木", ucn="U+6728")
+    session.add_all([with_def, without_def])
+    session.commit()
+
+    results = session.scalars(select(Unhn).where(Unhn.has_definition)).all()
+    chars = {r.char for r in results}
+    assert "金" in chars
+    assert "木" not in chars
+
+
+def test_definition_text(session: Session, engine: sqlalchemy.Engine) -> None:
+    """Test definition_text hybrid_property."""
+    Base.metadata.create_all(engine)
+    char = Unhn(char="土", ucn="U+571F")
+    char.kDefinition.append(kDefinition(definition="earth"))
+    session.add(char)
+    session.commit()
+
+    assert char.definition_text == "earth"
+
+    result = session.scalar(
+        select(Unhn.definition_text).where(Unhn.char == "土"),
+    )
+    assert result == "earth"
+
+
+def test_definition_count(session: Session, engine: sqlalchemy.Engine) -> None:
+    """Test definition_count column_property."""
+    Base.metadata.create_all(engine)
+    char = Unhn(char="日", ucn="U+65E5")
+    char.kDefinition.append(kDefinition(definition="sun"))
+    char.kDefinition.append(kDefinition(definition="day"))
+    session.add(char)
+    session.commit()
+
+    session.expire(char)
+    assert char.definition_count == 2

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import typing as t
 
+from sqlalchemy import func, select
+
 from unihan_db import bootstrap
-from unihan_db.tables import Base, Unhn
+from unihan_db.tables import Base, Unhn, kDefinition
 
 if t.TYPE_CHECKING:
     import pathlib
@@ -31,8 +33,8 @@ def test_import_object(session: Session, engine: sqlalchemy.Engine) -> None:
     session.add(Unhn(char="好", ucn="U+4E09"))
     session.commit()
 
-    assert session.query(Unhn)
-    assert session.query(Unhn).count() == 1
+    assert session.execute(select(Unhn)).scalars().first() is not None
+    assert session.scalar(select(func.count()).select_from(Unhn)) == 1
 
 
 def test_import_unihan(
@@ -57,3 +59,54 @@ def test_import_unihan_raw(
     bootstrap.bootstrap_unihan(session, unihan_options)
 
     session.commit()
+
+
+def test_unhn_repr(session: Session, engine: sqlalchemy.Engine) -> None:
+    """Test __repr__ on Unhn model."""
+    Base.metadata.create_all(engine)
+    char = Unhn(char="大", ucn="U+5927")
+    session.add(char)
+    session.commit()
+
+    assert repr(char) == "<Unhn char='大' ucn='U+5927'>"
+
+
+def test_base_repr(session: Session, engine: sqlalchemy.Engine) -> None:
+    """Test generic __repr__ on child model."""
+    Base.metadata.create_all(engine)
+    char = Unhn(char="中", ucn="U+4E2D")
+    defn = kDefinition(definition="middle")
+    char.kDefinition.append(defn)
+    session.add(char)
+    session.commit()
+
+    assert "<kDefinition id=" in repr(defn)
+
+
+def test_to_dict(session: Session, engine: sqlalchemy.Engine) -> None:
+    """Test Base.to_dict() method."""
+    Base.metadata.create_all(engine)
+    char = Unhn(char="人", ucn="U+4EBA")
+    defn = kDefinition(definition="person")
+    char.kDefinition.append(defn)
+    session.add(char)
+    session.commit()
+
+    result = char.to_dict()
+    assert result["char"] == "人"
+    assert result["ucn"] == "U+4EBA"
+    assert isinstance(result["kDefinition"], list)
+    assert len(result["kDefinition"]) == 1
+    assert result["kDefinition"][0]["definition"] == "person"
+
+
+def test_to_dict_compat(session: Session, engine: sqlalchemy.Engine) -> None:
+    """Test backward-compatible bootstrap.to_dict() wrapper."""
+    Base.metadata.create_all(engine)
+    char = Unhn(char="天", ucn="U+5929")
+    session.add(char)
+    session.commit()
+
+    result = bootstrap.to_dict(char)
+    assert result["char"] == "天"
+    assert result["ucn"] == "U+5929"


### PR DESCRIPTION
## Summary

- Fix two data-loss bugs in the importer: missing `kIRG_SSource`/`kIRG_UKSource` imports and `kFennIndex` locations passed as object instead of list
- Migrate all 35+ ORM models from legacy `Column()` to `Mapped[T]` + `mapped_column()` for full mypy type inference
- Add `index=True` to all FK columns for query performance on 21k+ characters
- Fix `UnhnLocation.virtual` from `Integer` to `Boolean` (semantic correctness)
- Add `__repr__` to `Base` (generic) and `Unhn` (char/ucn-specific) for debuggability
- Add `cascade="all, delete-orphan"` to all parent relationships, preventing orphaned rows on delete
- Add `back_populates` for standalone child tables enabling bidirectional navigation
- Fix FK ambiguity on `UnhnLocation` with explicit `foreign_keys` parameter
- Fix latent `to_dict()` recursion bug (passed wrong variable to recursive calls)
- Move `to_dict` from monkey-patch to proper `Base.to_dict()` method
- Remove unused `mapper_reg` registry and `setup_orm_mappings` event listener
- Remove module-level `setup_logger()` call (library logging best practice)
- Replace `sys.stdout.write` progress output with structured `log.info`
- Modernize to `select()` API, add `get_session_context()` context manager

## Test plan

- [x] All 27 existing tests pass on every commit
- [x] `uv run ruff check .` clean on every commit
- [x] `uv run ruff format --check .` clean on every commit
- [x] `uv run mypy` clean on every commit (including examples/)
- [x] Each commit verified individually via checkout + full gate run

## Breaking changes

- Schema changes (new indexes, `virtual` column type) require re-bootstrapping the database. Since databases are caches of upstream UNIHAN data, this is low-impact.