### PR TITLE
Docs(fix): link API references

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -36,6 +36,17 @@ $ uvx --from 'unihan-db' --prerelease allow python -c "import unihan_db.bootstra
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Documentation
+
+#### Linked bootstrap and table documentation (#366)
+
+The quickstart, homepage, and API reference now guide readers through the main
+unihan-db workflow: create or reuse a SQLAlchemy session, load UNIHAN data once,
+and query local `Unhn` rows. The docs also link the bootstrap helpers, importer
+internals, and ORM table classes at their first mention, so readers can move
+from overview prose to the exact API reference without hunting through the
+navigation.
+
 ## unihan-db 0.22.0 (2026-06-28)
 
 unihan-db 0.22.0 tracks the upstream `unihan-etl` 0.43.0 release. It raises the

--- a/docs/api/bootstrap.md
+++ b/docs/api/bootstrap.md
@@ -1,8 +1,15 @@
-# Bootstrap - `unihan_db.bootstrap`
+# Bootstrap Helpers
 
-```{module} unihan_db
+{mod}`unihan_db.bootstrap` is the load layer: it asks
+[unihan-etl](https://unihan-etl.git-pull.com/) for normalized UNIHAN records,
+creates the schema, and inserts rows when the database is still empty. For most
+uses, call {func}`unihan_db.bootstrap.get_session` for the default SQLite-backed
+session, then call {func}`unihan_db.bootstrap.bootstrap_unihan` once before
+querying.
 
-```
+For the rarer cases, {func}`unihan_db.bootstrap.bootstrap_data` exposes the ETL
+options, and {func}`unihan_db.bootstrap.to_dict` turns ORM rows into plain
+dictionaries for display or serialization.
 
 ```{eval-rst}
 .. automodule:: unihan_db.bootstrap

--- a/docs/api/importer.md
+++ b/docs/api/importer.md
@@ -1,8 +1,10 @@
-# Importing - `unihan_db.importer`
+# Importer Internals
 
-```{module} unihan_db
-
-```
+{mod}`unihan_db.importer` turns normalized
+[unihan-etl](https://unihan-etl.git-pull.com/) records into ORM rows. Most users
+do not call it directly; {func}`unihan_db.bootstrap.bootstrap_unihan` calls
+{func}`unihan_db.importer.import_char` while loading
+{class}`unihan_db.tables.Unhn` and its related tables.
 
 ```{eval-rst}
 .. automodule:: unihan_db.importer

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -2,15 +2,17 @@
 
 # API Reference
 
-```{module} unihan_db
-
-```
-
 :::{warning}
 Be careful with these! APIs are **not** covered considered stable pre-1.0. They can break or be removed between minor versions!
 
 If you need an internal API stabilized please [file an issue](https://github.com/cihai/unihan-db/issues).
 :::
+
+Most projects only need the bootstrap path: create a
+[SQLAlchemy](https://www.sqlalchemy.org/) session, run
+{func}`unihan_db.bootstrap.bootstrap_unihan`, and query
+{class}`unihan_db.tables.Unhn`. The reference pages below split the API by the
+same pipeline: load data, turn records into rows, then query the mapped tables.
 
 ::::{grid} 1 2 3 3
 :gutter: 2 2 3 3

--- a/docs/api/tables.md
+++ b/docs/api/tables.md
@@ -1,8 +1,10 @@
-# Tables - `unihan_db.tables`
+# ORM Tables
 
-```{module} unihan_db
-
-```
+{mod}`unihan_db.tables` defines the
+[SQLAlchemy](https://www.sqlalchemy.org/) ORM schema for UNIHAN data.
+{class}`unihan_db.tables.Base` owns the shared metadata, and
+{class}`unihan_db.tables.Unhn` is the central character table that readings,
+dictionary locations, variant forms, and indexes relate back to.
 
 ```{eval-rst}
 .. automodule:: unihan_db.tables

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,12 @@
 
 # unihan-db
 
-SQLAlchemy models for the [UNIHAN](https://www.unicode.org/charts/unihan.html) CJK character database.
+[SQLAlchemy](https://www.sqlalchemy.org/) models for the [UNIHAN](https://www.unicode.org/charts/unihan.html) CJK character database.
 unihan-db provides the schema and ORM layer. For the ETL pipeline, see [unihan-etl](https://unihan-etl.git-pull.com/). For end-user character lookups, see [cihai](https://cihai.git-pull.com/).
+
+Most projects use {func}`unihan_db.bootstrap.get_session` or their own SQLAlchemy
+engine, load the data once with {func}`unihan_db.bootstrap.bootstrap_unihan`, and
+then query {class}`unihan_db.tables.Unhn` and the tables that hang off it.
 
 ::::{grid} 1 2 3 3
 :gutter: 2 2 3 3
@@ -17,7 +21,7 @@ Install and load UNIHAN data in 5 minutes.
 :::{grid-item-card} Models & Bootstrap
 :link: api/index
 :link-type: doc
-Table models, bootstrap loader, and data importer.
+Table models, bootstrap helpers, and importer internals.
 :::
 
 :::{grid-item-card} Contributing
@@ -62,7 +66,7 @@ with Session(engine) as session:
         print(char.char, char.ucn)
 ```
 
-See [Quickstart](quickstart.md) for the full setup, including bootstrapping
+See {doc}`quickstart` for the full setup, including bootstrapping
 data from the Unicode consortium.
 
 ```{toctree}

--- a/docs/project/index.md
+++ b/docs/project/index.md
@@ -16,7 +16,7 @@ Development setup and how to get involved.
 :::{grid-item-card} Code Style
 :link: code-style
 :link-type: doc
-Ruff, mypy, and import conventions.
+[Ruff](https://github.com/astral-sh/ruff), [mypy](https://github.com/python/mypy), and import conventions.
 :::
 
 :::{grid-item-card} Releasing

--- a/docs/project/releasing.md
+++ b/docs/project/releasing.md
@@ -26,6 +26,7 @@ unihan-db is pre-1.0. APIs may change between minor versions.
 
 ## Publishing
 
-Releases are published to PyPI via GitHub Actions using
+Releases are published to [PyPI](https://pypi.org/) via
+[GitHub Actions](https://docs.github.com/actions) using
 [trusted publishing (OIDC)](https://docs.pypi.org/trusted-publishers/).
 Pushing a version tag triggers the publish workflow automatically.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,9 +2,16 @@
 
 # Quickstart
 
+unihan-db turns UNIHAN into local [SQLAlchemy](https://www.sqlalchemy.org/)
+tables. For the common path, create a session with
+{func}`unihan_db.bootstrap.get_session`, load the data once with
+{func}`unihan_db.bootstrap.bootstrap_unihan`, and query
+{class}`unihan_db.tables.Unhn` or its related tables. The first bootstrap
+downloads and imports the archive; after that, your queries use local SQLite.
+
 ## Installation
 
-Assure you have at least python **>= 3.7**.
+Use [Python] **>=3.10,<4.0**.
 
 Using [pip]:
 
@@ -24,11 +31,13 @@ Run code without installing by using [uvx]:
 $ uvx --from unihan-db python -c "import unihan_db.bootstrap as bootstrap; print(bootstrap.TABLE_NAME)"
 ```
 
-Install into an isolated environment with [pipx] (exposes the `unihan-etl` CLI from dependencies):
+Install into an isolated environment with [pipx]:
 
 ```console
 $ pipx install 'unihan-db' --include-deps
 ```
+
+The dependency set includes the [unihan-etl] CLI.
 
 You can upgrade to the latest release with:
 
@@ -36,11 +45,29 @@ You can upgrade to the latest release with:
 $ pip install --upgrade unihan-db
 ```
 
+## Usage
+
+The example creates a session, runs the bootstrap, queries a random
+{class}`~unihan_db.tables.Unhn` row, and shows both
+{func}`unihan_db.bootstrap.to_dict` and the row's injected `to_dict()` helper.
+
+```{literalinclude} ../examples/01_bootstrap.py
+:language: python
+```
+
+## Pythonics
+
+:::{seealso}
+
+{ref}`unihan-db's API documentation <api>`.
+
+:::
+
 (developmental-releases)=
 
-### Developmental releases
+## Developmental releases
 
-New versions of unihan-db are published to PyPI as alpha, beta, or release candidates. In their
+New versions of unihan-db are published to [PyPI] as alpha, beta, or release candidates. In their
 versions you will see notification like `a1`, `b1`, and `rc1`, respectively. `1.10.0b4` would mean
 the 4th beta release of `1.10.0` before general availability.
 
@@ -54,8 +81,9 @@ the 4th beta release of `1.10.0` before general availability.
 
   ```console
   $ pipx install --suffix=@next 'unihan-db' --pip-args '\--pre' --include-deps --force
-  // Provides the unihan-etl CLI from the dependency set.
   ```
+
+  This also installs the [unihan-etl] CLI from the dependency set.
 
 - [uv]:
 
@@ -91,17 +119,8 @@ via trunk (can break easily):
 
 [pip]: https://pip.pypa.io/en/stable/
 [pipx]: https://pypa.github.io/pipx/docs/
+[PyPI]: https://pypi.org/
+[Python]: https://www.python.org/
+[unihan-etl]: https://unihan-etl.git-pull.com/
 [uv]: https://docs.astral.sh/uv/
 [uvx]: https://docs.astral.sh/uv/guides/tools/
-
-## Usage
-
-```{literalinclude} ../examples/01_bootstrap.py
-:language: python
-```
-
-## Pythonics
-
-:::{seealso}
-
-{ref}`unihan-db's API documentation <api>`.


### PR DESCRIPTION
## Summary
- Link first prose mentions across docs with MyST/Sphinx roles
- Rework API and quickstart intros around the default bootstrap flow
- Add an unreleased changelog entry for the reader-facing docs cleanup
- Remove duplicate module context directives so the docs build is warning-free

## Validation
- `rm -rf docs/_build; uv run ruff check . --fix --show-fixes; uv run ruff format .; uv run mypy .; uv run py.test --reruns 0 -vvv; just build-docs`
- Result: Ruff clean, mypy clean, 5 tests passed, docs build succeeded without warnings