### PR TITLE
Docs: add tested workflow guides

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Build documentation
         if: env.PUBLISH == 'true'
         run: |
-          cd docs && just html
+          cd docs && just html && just doctest
 
       - name: Configure AWS Credentials
         if: env.PUBLISH == 'true'

--- a/CHANGES
+++ b/CHANGES
@@ -360,10 +360,10 @@ workflows.
 
 ### Fixes
 
-#### `as_dict()` works on model rows again (#325)
+#### `to_dict()` works on model rows again (#325)
 
 The SQLAlchemy mapper event wiring for {func}`~unihan_db.bootstrap.add_to_dict`
-was fixed, restoring `row.as_dict()` on {class}`~unihan_db.tables.Unhn` rows.
+was fixed, restoring `row.to_dict()` on {class}`~unihan_db.tables.Unhn` rows.
 This makes the object-to-dictionary helper path usable again after the mapper
 callback regression.
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -63,19 +63,20 @@ comprehension tax for the advanced one.
 
 ## Examples that run
 
-Doctests under `docs/` execute: `testpaths` includes `docs`, and
-pytest-doctest-docutils (from gp-libs) collects every `>>>` block in a
-Markdown page. `ELLIPSIS` and `NORMALIZE_WHITESPACE` are on globally,
-so variable output can be elided without a per-line flag.
+Doctests under `docs/` execute through Sphinx: `just build-docs` runs
+both the HTML builder and the Sphinx doctest builder. Use MyST
+```` ```{doctest} ```` blocks for Python sessions that must execute.
+`ELLIPSIS` and `NORMALIZE_WHITESPACE` are on globally, so variable
+output can be elided without a per-line flag.
 
-- The root `conftest.py` puts `tmp_path` in the `doctest_namespace`
-  and redirects `HOME` and the working directory to temporary paths,
-  so a doctest can create a throwaway SQLite file safely.
+- `docs/conf.py` puts `tmp_path` in the Sphinx doctest namespace and
+  redirects `HOME` and the working directory to temporary paths, so a
+  doctest can create a throwaway SQLite file safely.
 - Tests run offline. `bootstrap_unihan` against real UNIHAN data
   downloads from unicode.org — keep it out of doctests. Show schema
   creation, in-memory engines, and ORM objects instead, the way
   `tests/` does with its zipped fixtures.
-- Fence a `>>>` session as a ```` ```python ```` block; use a
+- Fence an executable `>>>` session as a ```` ```{doctest} ```` block; use a
   ```` ```console ```` block for shell commands at a `$` prompt.
 
 ## What stays precise

--- a/docs/api/bootstrap.md
+++ b/docs/api/bootstrap.md
@@ -1,15 +1,18 @@
 # Bootstrap Helpers
 
 {mod}`unihan_db.bootstrap` is the load layer: it asks
-[unihan-etl](https://unihan-etl.git-pull.com/) for normalized UNIHAN records,
+[unihan-etl](https://unihan-etl.git-pull.com/) for normalized [UNIHAN] records,
 creates the schema, and inserts rows when the database is still empty. For most
-uses, call {func}`unihan_db.bootstrap.get_session` for the default SQLite-backed
+uses, call {func}`unihan_db.bootstrap.get_session` for the default [SQLite]-backed
 session, then call {func}`unihan_db.bootstrap.bootstrap_unihan` once before
 querying.
 
 For the rarer cases, {func}`unihan_db.bootstrap.bootstrap_data` exposes the ETL
 options, and {func}`unihan_db.bootstrap.to_dict` turns ORM rows into plain
 dictionaries for display or serialization.
+
+[SQLite]: https://www.sqlite.org/
+[UNIHAN]: https://www.unicode.org/charts/unihan.html
 
 ```{eval-rst}
 .. automodule:: unihan_db.bootstrap

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -28,7 +28,7 @@ Data download, session helpers, and ETL options.
 :::{grid-item-card} Importer
 :link: importer
 :link-type: doc
-Transform normalized UNIHAN records into ORM objects.
+Transform normalized [UNIHAN] records into ORM objects.
 :::
 
 :::{grid-item-card} Tables
@@ -38,6 +38,8 @@ SQLAlchemy ORM models for UNIHAN data.
 :::
 
 ::::
+
+[UNIHAN]: https://www.unicode.org/charts/unihan.html
 
 ```{toctree}
 :caption: API

--- a/docs/api/tables.md
+++ b/docs/api/tables.md
@@ -1,10 +1,13 @@
 # ORM Tables
 
 {mod}`unihan_db.tables` defines the
-[SQLAlchemy](https://www.sqlalchemy.org/) ORM schema for UNIHAN data.
-{class}`unihan_db.tables.Base` owns the shared metadata, and
+[SQLAlchemy](https://www.sqlalchemy.org/) ORM schema for [UNIHAN] data.
+{attr}`unihan_db.tables.Base.metadata` owns the shared metadata, and
 {class}`unihan_db.tables.Unhn` is the central character table that readings,
-dictionary locations, variant forms, and indexes relate back to.
+dictionary locations, IRG source records, radical/stroke data, and indexes
+relate back to.
+
+[UNIHAN]: https://www.unicode.org/charts/unihan.html
 
 ```{eval-rst}
 .. automodule:: unihan_db.tables

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import doctest
 import pathlib
 import sys
 
@@ -30,10 +31,10 @@ conf = merge_sphinx_config(
     source_branch="master",
     light_logo="img/cihai.svg",
     dark_logo="img/cihai.svg",
-    extra_extensions=["sphinx_autodoc_api_style"],
+    extra_extensions=["sphinx.ext.doctest", "sphinx_autodoc_api_style"],
     intersphinx_mapping={
-        "python": ("http://docs.python.org/3/", None),
-        "sqlalchemy": ("http://docs.sqlalchemy.org/en/latest/", None),
+        "python": ("https://docs.python.org/3/", None),
+        "sqlalchemy": ("https://docs.sqlalchemy.org/en/21/", None),
     },
     linkcode_resolve=make_linkcode_resolve(unihan_db, about["__github__"]),
     html_favicon="_static/favicon.ico",
@@ -44,3 +45,25 @@ conf = merge_sphinx_config(
     exclude_patterns=["_build", "AGENTS.md", "CLAUDE.md"],
 )
 globals().update(conf)
+
+doctest_default_flags = doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
+doctest_global_setup = """
+import os
+import pathlib
+import tempfile
+
+_doctest_tmpdir = tempfile.TemporaryDirectory()
+tmp_path = pathlib.Path(_doctest_tmpdir.name)
+_doctest_old_home = os.environ.get("HOME")
+_doctest_old_cwd = pathlib.Path.cwd()
+os.environ["HOME"] = str(tmp_path)
+os.chdir(tmp_path)
+"""
+doctest_global_cleanup = """
+os.chdir(_doctest_old_cwd)
+if _doctest_old_home is None:
+    os.environ.pop("HOME", None)
+else:
+    os.environ["HOME"] = _doctest_old_home
+_doctest_tmpdir.cleanup()
+"""

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,0 +1,23 @@
+(explanation)=
+
+# Explanation
+
+These pages describe how unihan-db fits together. Read them when you need the
+shape of the system rather than a step-by-step task.
+
+::::{grid} 1 1 2 2
+:gutter: 2
+
+:::{grid-item-card} Pipeline and Schema
+:link: pipeline-and-schema
+:link-type: doc
+How unihan-etl records become local ORM rows.
+:::
+
+::::
+
+```{toctree}
+:hidden:
+
+pipeline-and-schema
+```

--- a/docs/explanation/pipeline-and-schema.md
+++ b/docs/explanation/pipeline-and-schema.md
@@ -1,0 +1,23 @@
+(pipeline-and-schema)=
+
+# Pipeline and Schema
+
+unihan-db has one main path: [unihan-etl](https://unihan-etl.git-pull.com/)
+fetches and normalizes [UNIHAN](https://www.unicode.org/charts/unihan.html)
+records, {func}`unihan_db.bootstrap.bootstrap_unihan` inserts those records
+once, and application code queries {class}`unihan_db.tables.Unhn` through
+[SQLAlchemy](https://www.sqlalchemy.org/).
+
+{func}`unihan_db.bootstrap.get_session` is the default entry point for
+applications. It creates the schema and returns a scoped SQLAlchemy session
+bound to the default SQLite database. Use a custom database URL only when your
+application needs to control where the database lives.
+
+{mod}`unihan_db.importer` is the narrower layer that turns normalized records
+into ORM objects. Most users do not call it directly; it exists so the bootstrap
+step can keep download/export concerns separate from row construction.
+
+{mod}`unihan_db.tables` is the reference surface for the mapped tables. The
+central model is {class}`unihan_db.tables.Unhn`; related reading, dictionary
+location, radical/stroke, source, and index rows connect back to that character
+row.

--- a/docs/how-to/custom-database.md
+++ b/docs/how-to/custom-database.md
@@ -1,0 +1,25 @@
+(custom-database)=
+
+# Use a Custom Database
+
+{func}`unihan_db.bootstrap.get_session` stores the default SQLite database in
+the current user's XDG data directory. Pass an explicit SQLAlchemy database URL
+when your application should own the database location.
+
+Use a file URL such as `sqlite:////path/to/unihan.db` for a persistent SQLite
+database. After you have the session, the rest of the workflow is unchanged:
+call {func}`unihan_db.bootstrap.bootstrap_unihan` once, then query
+{class}`unihan_db.tables.Unhn` rows.
+
+```{doctest}
+>>> from unihan_db.bootstrap import get_session
+>>> db_path = tmp_path / "unihan.db"
+>>> session = get_session(f"sqlite:///{db_path}")
+>>> db_path.exists()
+True
+>>> session.remove()
+```
+
+For test suites, prefer an in-memory SQLAlchemy engine and the fixtures in
+`tests/` so the first bootstrap can use a local UNIHAN archive instead of the
+network.

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,0 +1,37 @@
+(how-to)=
+
+# How-to Guides
+
+Use these guides when you already know the basic bootstrap path and need to
+adapt it to a specific task.
+
+::::{grid} 1 1 2 2
+:gutter: 2
+
+:::{grid-item-card} Use a Custom Database
+:link: custom-database
+:link-type: doc
+Point unihan-db at a project-owned SQLite file.
+:::
+
+:::{grid-item-card} Bootstrap from a Local Archive
+:link: offline-bootstrap
+:link-type: doc
+Load UNIHAN data from a local archive for tests or offline runs.
+:::
+
+:::{grid-item-card} Query Local Rows
+:link: query-related-tables
+:link-type: doc
+Create rows, query them, and turn ORM objects into dictionaries.
+:::
+
+::::
+
+```{toctree}
+:hidden:
+
+custom-database
+offline-bootstrap
+query-related-tables
+```

--- a/docs/how-to/offline-bootstrap.md
+++ b/docs/how-to/offline-bootstrap.md
@@ -1,0 +1,18 @@
+(offline-bootstrap)=
+
+# Bootstrap from a Local Archive
+
+{func}`unihan_db.bootstrap.bootstrap_unihan` accepts the same ETL options as
+{func}`unihan_db.bootstrap.bootstrap_data`. Pass a local `source` archive when
+you need deterministic tests, offline development, or a pre-downloaded UNIHAN
+zip.
+
+The repository tests use this path: `tests/conftest.py` builds a local archive
+from `tests/fixtures/`, then passes `source`, `work_dir`, and `zip_path` through
+the `unihan_options` fixture. That keeps bootstrap coverage offline while still
+exercising the real importer.
+
+Use the default options for normal applications. The default path downloads the
+current UNIHAN archive through
+[unihan-etl](https://unihan-etl.git-pull.com/) and then reuses the local
+database on later runs.

--- a/docs/how-to/query-related-tables.md
+++ b/docs/how-to/query-related-tables.md
@@ -1,0 +1,33 @@
+(query-related-tables)=
+
+# Query Local Rows
+
+Once the schema exists, querying unihan-db is ordinary
+[SQLAlchemy](https://www.sqlalchemy.org/) ORM work. The central table is
+{class}`unihan_db.tables.Unhn`; related reading, dictionary-location,
+radical/stroke, source, and index tables hang off each character row.
+
+The small example below stays offline by creating one row directly instead of
+running the full UNIHAN bootstrap.
+
+```{doctest}
+>>> from sqlalchemy import create_engine
+>>> from sqlalchemy.orm import Session
+>>> from unihan_db.bootstrap import to_dict
+>>> from unihan_db.tables import Base, Unhn
+>>> engine = create_engine("sqlite:///:memory:")
+>>> Base.metadata.create_all(engine)
+>>> session = Session(engine)
+>>> session.add(Unhn(char="好", ucn="U+597D"))
+>>> session.commit()
+>>> row = session.query(Unhn).filter_by(char="好").one()
+>>> row.char, row.ucn
+('好', 'U+597D')
+>>> to_dict(row)["char"]
+'好'
+>>> session.close()
+```
+
+Use {func}`unihan_db.bootstrap.to_dict` when you need a plain dictionary for
+display or serialization. For real data, call
+{func}`unihan_db.bootstrap.bootstrap_unihan` before running the query.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,10 +18,22 @@ then query {class}`unihan_db.tables.Unhn` and the tables that hang off it.
 Install and load UNIHAN data in 5 minutes.
 :::
 
+:::{grid-item-card} How-to Guides
+:link: how-to/index
+:link-type: doc
+Common tasks: custom databases, offline bootstraps, and ORM queries.
+:::
+
 :::{grid-item-card} Models & Bootstrap
 :link: api/index
 :link-type: doc
 Table models, bootstrap helpers, and importer internals.
+:::
+
+:::{grid-item-card} Explanation
+:link: explanation/index
+:link-type: doc
+How the ETL pipeline, bootstrap step, and ORM schema fit together.
 :::
 
 :::{grid-item-card} Contributing
@@ -44,26 +56,11 @@ $ uv add unihan-db
 
 ## At a glance
 
-```python
-from sqlalchemy import create_engine
-from sqlalchemy.orm import Session
+The same bootstrap example appears in the quickstart and is executed by the test
+suite.
 
-from unihan_db.bootstrap import bootstrap_unihan
-from unihan_db.tables import Base, Unhn
-
-engine = create_engine("sqlite:///unihan.db")
-
-# Step 1: Create the schema
-Base.metadata.create_all(engine)
-
-# Step 2: Bootstrap data from the Unicode consortium
-bootstrap_unihan(engine)
-
-# Step 3: Query characters
-with Session(engine) as session:
-    char = session.query(Unhn).filter_by(char="\u597D").first()
-    if char:
-        print(char.char, char.ucn)
+```{literalinclude} ../examples/01_bootstrap.py
+:language: python
 ```
 
 See {doc}`quickstart` for the full setup, including bootstrapping
@@ -73,7 +70,9 @@ data from the Unicode consortium.
 :hidden:
 
 quickstart
+how-to/index
 api/index
+explanation/index
 project/index
 history
 GitHub <https://github.com/cihai/unihan-db>

--- a/docs/project/code-style.md
+++ b/docs/project/code-style.md
@@ -30,5 +30,5 @@ $ uv run mypy src tests
 
 - `from __future__ import annotations` in every module.
 - Namespace imports for stdlib: `import typing as t`.
-- NumPy-style docstrings.
+- [NumPy-style docstrings](https://numpydoc.readthedocs.io/en/latest/format.html).
 - See `[tool.ruff]` in `pyproject.toml` for the full rule set.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,12 +2,12 @@
 
 # Quickstart
 
-unihan-db turns UNIHAN into local [SQLAlchemy](https://www.sqlalchemy.org/)
+unihan-db turns [UNIHAN] into local [SQLAlchemy](https://www.sqlalchemy.org/)
 tables. For the common path, create a session with
 {func}`unihan_db.bootstrap.get_session`, load the data once with
 {func}`unihan_db.bootstrap.bootstrap_unihan`, and query
 {class}`unihan_db.tables.Unhn` or its related tables. The first bootstrap
-downloads and imports the archive; after that, your queries use local SQLite.
+downloads and imports the archive; after that, your queries use local [SQLite].
 
 ## Installation
 
@@ -50,18 +50,12 @@ $ pip install --upgrade unihan-db
 The example creates a session, runs the bootstrap, queries a random
 {class}`~unihan_db.tables.Unhn` row, and shows both
 {func}`unihan_db.bootstrap.to_dict` and the row's injected `to_dict()` helper.
+For the API details behind those helpers, see
+{ref}`unihan-db's API documentation <api>`.
 
 ```{literalinclude} ../examples/01_bootstrap.py
 :language: python
 ```
-
-## Pythonics
-
-:::{seealso}
-
-{ref}`unihan-db's API documentation <api>`.
-
-:::
 
 (developmental-releases)=
 
@@ -123,6 +117,8 @@ can change before the next release:
 [pipx]: https://pypa.github.io/pipx/docs/
 [PyPI]: https://pypi.org/
 [Python]: https://www.python.org/
+[SQLite]: https://www.sqlite.org/
+[UNIHAN]: https://www.unicode.org/charts/unihan.html
 [unihan-etl]: https://unihan-etl.git-pull.com/
 [uv]: https://docs.astral.sh/uv/
 [uvx]: https://docs.astral.sh/uv/guides/tools/

--- a/examples/01_bootstrap.py
+++ b/examples/01_bootstrap.py
@@ -19,7 +19,7 @@ def run(unihan_options: dict[str, object] | None = None) -> None:
     """Initialize Unihan DB via ``bootstrap_unihan()``."""
     session = bootstrap.get_session()
 
-    bootstrap.bootstrap_unihan(session)
+    bootstrap.bootstrap_unihan(session, unihan_options)
 
     random_row_query = session.query(Unhn).order_by(func.random()).limit(1)
 

--- a/justfile
+++ b/justfile
@@ -37,6 +37,7 @@ watch-test:
 [group: 'docs']
 build-docs:
     just -f docs/justfile html
+    just -f docs/justfile doctest
 
 # Watch files and rebuild docs on change
 [group: 'docs']

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -1,0 +1,75 @@
+"""Tests for documentation example contracts."""
+
+from __future__ import annotations
+
+import pathlib
+import typing as t
+
+import pytest
+
+from .test_example import load_script
+
+if t.TYPE_CHECKING:
+    from .types import UnihanOptions
+
+
+class DocsContentCase(t.NamedTuple):
+    """Expected source-level contract for one docs page."""
+
+    test_id: str
+    path: pathlib.Path
+    required_text: str
+    forbidden_text: str
+
+
+def test_bootstrap_example_forwards_unihan_options(
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: pathlib.Path,
+    unihan_options: UnihanOptions,
+) -> None:
+    """The literal-included bootstrap example must support offline fixture options."""
+    example = load_script("01_bootstrap", project_root=project_root)
+
+    class StopExample(Exception):
+        """Stop the example after the bootstrap call is observed."""
+
+    observed: dict[str, object | None] = {}
+
+    def fake_bootstrap_unihan(session: object, options: object | None = None) -> None:
+        observed["session"] = session
+        observed["options"] = options
+        raise StopExample
+
+    monkeypatch.setattr(example.bootstrap, "bootstrap_unihan", fake_bootstrap_unihan)
+
+    with pytest.raises(StopExample):
+        example.run(unihan_options)
+
+    assert observed["options"] is unihan_options
+
+
+DOCS_CONTENT_CASES: tuple[DocsContentCase, ...] = (
+    DocsContentCase(
+        test_id="homepage-uses-tested-bootstrap-example",
+        path=pathlib.Path("docs/index.md"),
+        required_text="```{literalinclude} ../examples/01_bootstrap.py",
+        forbidden_text="bootstrap_unihan(engine)",
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "case",
+    DOCS_CONTENT_CASES,
+    ids=[case.test_id for case in DOCS_CONTENT_CASES],
+)
+def test_docs_pages_use_tested_examples(
+    project_root: pathlib.Path,
+    case: DocsContentCase,
+) -> None:
+    """Docs pages should reuse tested examples instead of drifting inline snippets."""
+    page = project_root / case.path
+    source = page.read_text(encoding="utf-8")
+
+    assert case.required_text in source
+    assert case.forbidden_text not in source

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -47,4 +47,4 @@ def test_01_bootstrap(
 ) -> None:
     """Test example dataset."""
     example = load_script("01_bootstrap", project_root=project_root)
-    example.run()
+    example.run(unihan_options)


### PR DESCRIPTION
## Summary

- Reuse the tested bootstrap example on the homepage so onboarding docs stay aligned with the bootstrap API.
- Add how-to and explanation pages for custom databases, offline bootstraps, query workflows, and the ETL-to-ORM pipeline.
- Run Sphinx doctests as part of the docs build gate, including temporary HOME/cwd setup for safe SQLite examples.
- Correct stale API prose and changelog wording around linked objects and `to_dict()`.

## Testing

- [x] `rm -rf docs/_build`
- [x] `uv run ruff check . --fix --show-fixes`
- [x] `uv run ruff format .`
- [x] `uv run mypy .`
- [x] `uv run py.test --reruns 0 -vvv`
- [x] `just build-docs`
